### PR TITLE
Fix skipped middle point when connecting opposite corners

### DIFF
--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -223,6 +223,8 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                 } else if (drawingPattern.isEmpty() ||
                         (drawingPattern.getLast() != (byte) i && !hasOverlappingLines(drawingPattern, drawingPattern.getLast(), (byte) i))) {
                     drawingPattern.add((byte) i);
+                    if(drawingPattern.size() > 1 && drawingPattern.get(drawingPattern.size() - 2) == (byte) (8 - i))
+                        drawingPattern.add(drawingPattern.size() - 1, (byte) 4);
                     // TODO click sound?
                     MinecraftClient.getInstance().player.playSoundToPlayer(
                             ModSounds.DRAW, SoundCategory.MASTER,

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -223,8 +223,11 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                 } else if (drawingPattern.isEmpty() ||
                         (drawingPattern.getLast() != (byte) i && !hasOverlappingLines(drawingPattern, drawingPattern.getLast(), (byte) i))) {
                     drawingPattern.add((byte) i);
+
+                    //add middle point to path if connecting opposite corners
                     if(drawingPattern.size() > 1 && drawingPattern.get(drawingPattern.size() - 2) == (byte) (8 - i))
                         drawingPattern.add(drawingPattern.size() - 1, (byte) 4);
+
                     // TODO click sound?
                     MinecraftClient.getInstance().player.playSoundToPlayer(
                             ModSounds.DRAW, SoundCategory.MASTER,


### PR DESCRIPTION
e.g. drawing from `1` to `7` will force to `4` to be included in between, resulting in `1 4 7`