### PR TITLE
Render circle when editing

### DIFF
--- a/src/client/java/dev/enjarai/trickster/TricksterClient.java
+++ b/src/client/java/dev/enjarai/trickster/TricksterClient.java
@@ -1,14 +1,22 @@
 package dev.enjarai.trickster;
 
 import dev.enjarai.trickster.block.ModBlocks;
+import dev.enjarai.trickster.cca.ModCumponents;
+import dev.enjarai.trickster.net.IsEditingScrollPacket;
+import dev.enjarai.trickster.net.MladyPacket;
+import dev.enjarai.trickster.net.ModNetworking;
 import dev.enjarai.trickster.particle.ModParticles;
 import dev.enjarai.trickster.particle.ProtectedBlockParticle;
 import dev.enjarai.trickster.render.SpellCircleBlockEntityRenderer;
 import dev.enjarai.trickster.screen.ModHandledScreens;
+import dev.enjarai.trickster.screen.ScrollAndQuillScreen;
 import dev.enjarai.trickster.screen.owo.GlyphComponent;
 import io.wispforest.owo.ui.parsing.UIParsing;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
 
 public class TricksterClient implements ClientModInitializer {
@@ -23,5 +31,12 @@ public class TricksterClient implements ClientModInitializer {
 		UIParsing.registerFactory(Trickster.id("pattern"), GlyphComponent::parseList);
 
 		ParticleFactoryRegistry.getInstance().register(ModParticles.PROTECTED_BLOCK, ProtectedBlockParticle.Factory::new);
+
+		ClientTickEvents.END_CLIENT_TICK.register(client -> {
+			if (client.player != null) {
+				var is_editing = client.currentScreen instanceof ScrollAndQuillScreen;
+				ModNetworking.CHANNEL.clientHandle().send(new IsEditingScrollPacket(is_editing));
+			}
+		});
 	}
 }

--- a/src/client/java/dev/enjarai/trickster/mixin/client/PlayerRendererMixin.java
+++ b/src/client/java/dev/enjarai/trickster/mixin/client/PlayerRendererMixin.java
@@ -1,10 +1,13 @@
 package dev.enjarai.trickster.mixin.client;
 
 
+import dev.enjarai.trickster.cca.ModCumponents;
 import dev.enjarai.trickster.item.ModItems;
 import dev.enjarai.trickster.item.component.ModComponents;
 import dev.enjarai.trickster.render.SpellCircleRenderer;
+import dev.enjarai.trickster.screen.ScrollAndQuillScreen;
 import dev.enjarai.trickster.spell.SpellPart;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
@@ -58,13 +61,14 @@ public abstract class PlayerRendererMixin {
         var offHandSpell = offHandStack.get(ModComponents.SPELL);
 
         // TODO only appear when scroll is being edited
-
-        if (mainHandStack.isIn(ModItems.SCROLLS) && mainHandSpell != null) {
-            return Optional.of(mainHandSpell.spell());
-        } else if (offHandStack.isIn(ModItems.SCROLLS) && offHandSpell != null) {
-            return Optional.of(offHandSpell.spell());
-        } else {
-            return Optional.empty();
+        if (entity.getComponent(ModCumponents.IS_EDITING_SCROLL).isEditing()) {
+            if (mainHandStack.get(ModComponents.SPELL) != null && mainHandSpell != null) {
+                return Optional.of(mainHandSpell.spell());
+            } else if (mainHandStack.get(ModComponents.SPELL) != null && offHandSpell != null) {
+                return Optional.of(offHandSpell.spell());
+            }
         }
+        return Optional.empty();
+
     }
 }

--- a/src/client/java/dev/enjarai/trickster/render/SpellCircleRenderer.java
+++ b/src/client/java/dev/enjarai/trickster/render/SpellCircleRenderer.java
@@ -2,6 +2,7 @@ package dev.enjarai.trickster.render;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import dev.enjarai.trickster.Trickster;
+import dev.enjarai.trickster.spell.Fragment;
 import dev.enjarai.trickster.spell.PatternGlyph;
 import dev.enjarai.trickster.spell.SpellPart;
 import net.minecraft.client.MinecraftClient;
@@ -9,6 +10,7 @@ import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.RotationAxis;
 import net.minecraft.util.math.Vec3d;
 import org.joml.Matrix4f;
 import org.joml.Vector2f;
@@ -131,7 +133,20 @@ public class SpellCircleRenderer {
         var glyph = parent.getGlyph();
         if (glyph instanceof SpellPart part) {
             renderPart(matrices, vertexConsumers, Optional.of(part), x, y, size / 3, startingAngle, delta, alphaGetter, normal);
-        } else if (glyph instanceof PatternGlyph pattern) {
+        } else {
+            matrices.push();
+            drawSide(matrices, vertexConsumers, parent, x, y, size, glyph);
+            matrices.pop();
+
+            matrices.push();
+            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
+            drawSide(matrices, vertexConsumers, parent, -x, y, size, glyph);
+            matrices.pop();
+        }
+    }
+
+    private void drawSide(MatrixStack matrices, VertexConsumerProvider vertexConsumers, SpellPart parent, float x, float y, float size, Fragment glyph) {
+        if (glyph instanceof PatternGlyph pattern) {
             var patternSize = size / PATTERN_TO_PART_RATIO;
             var pixelSize = patternSize / PART_PIXEL_RADIUS;
 

--- a/src/main/java/dev/enjarai/trickster/cca/IsEditingScrollComponent.java
+++ b/src/main/java/dev/enjarai/trickster/cca/IsEditingScrollComponent.java
@@ -1,0 +1,58 @@
+package dev.enjarai.trickster.cca;
+
+import dev.enjarai.trickster.Trickster;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.ladysnake.cca.api.v3.component.sync.AutoSyncedComponent;
+
+import java.util.UUID;
+
+public class IsEditingScrollComponent implements AutoSyncedComponent {
+    private final PlayerEntity player;
+
+    private Boolean editing = false;
+
+    public IsEditingScrollComponent(PlayerEntity player) {
+        this.player = player;
+    }
+
+    @Override
+    public void readFromNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
+        if (tag.contains("editing")) {
+            setEditing(tag.getBoolean("editing"));
+        } else setEditing(false);
+    }
+
+    @Override
+    public void writeToNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
+        tag.putBoolean("editing", isEditing());
+    }
+
+    @Override
+    public void applySyncPacket(RegistryByteBuf buf) {
+        if (buf.readBoolean()) {
+            editing = buf.readBoolean();
+        } else {
+            editing = false;
+        }
+    }
+
+    @Override
+    public void writeSyncPacket(RegistryByteBuf buf, ServerPlayerEntity recipient) {
+        buf.writeBoolean(true);
+        buf.writeBoolean(editing);
+    }
+
+    public Boolean isEditing() {
+        return editing;
+    }
+
+    public void setEditing(Boolean editing) {
+        this.editing = editing;
+        ModCumponents.IS_EDITING_SCROLL.sync(player);
+    }
+
+}

--- a/src/main/java/dev/enjarai/trickster/cca/ModCumponents.java
+++ b/src/main/java/dev/enjarai/trickster/cca/ModCumponents.java
@@ -11,8 +11,13 @@ public class ModCumponents implements EntityComponentInitializer {
     public static final ComponentKey<DisguiseCumponent> DISGUISE =
             ComponentRegistry.getOrCreate(Trickster.id("disguise"), DisguiseCumponent.class);
 
+    public static final ComponentKey<IsEditingScrollComponent> IS_EDITING_SCROLL =
+            ComponentRegistry.getOrCreate(Trickster.id("is_editing_scroll"), IsEditingScrollComponent.class);
+
     @Override
     public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
         registry.registerForPlayers(DISGUISE, DisguiseCumponent::new, RespawnCopyStrategy.LOSSLESS_ONLY);
+        registry.registerForPlayers(IS_EDITING_SCROLL, IsEditingScrollComponent::new, RespawnCopyStrategy.NEVER_COPY);
+
     }
 }

--- a/src/main/java/dev/enjarai/trickster/net/IsEditingScrollPacket.java
+++ b/src/main/java/dev/enjarai/trickster/net/IsEditingScrollPacket.java
@@ -1,0 +1,4 @@
+package dev.enjarai.trickster.net;
+
+public record IsEditingScrollPacket(boolean isEditing) {
+}

--- a/src/main/java/dev/enjarai/trickster/net/ModNetworking.java
+++ b/src/main/java/dev/enjarai/trickster/net/ModNetworking.java
@@ -1,6 +1,7 @@
 package dev.enjarai.trickster.net;
 
 import dev.enjarai.trickster.Trickster;
+import dev.enjarai.trickster.cca.ModCumponents;
 import dev.enjarai.trickster.item.ModItems;
 import dev.enjarai.trickster.item.component.ModComponents;
 import dev.enjarai.trickster.item.component.SelectedSlotComponent;
@@ -81,6 +82,11 @@ public class ModNetworking {
                     }
                 }
             }
+        });
+
+        CHANNEL.registerServerbound(IsEditingScrollPacket.class, (packet, access) -> {
+            var player = access.player();
+            player.getComponent(ModCumponents.IS_EDITING_SCROLL).setEditing(packet.isEditing());
         });
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,8 @@
 	},
 	"custom": {
 		"cardinal-components": [
-			"trickster:disguise"
+			"trickster:disguise",
+			"trickster:is_editing_scroll"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
- makes a spell circle render in front of a player when they are editing a spell (on a scroll or a mirror)
- makes glyphs render on both sides of the spell circle