### PR TITLE
Fix handling of blood mana costs

### DIFF
--- a/src/main/java/dev/enjarai/trickster/Trickster.java
+++ b/src/main/java/dev/enjarai/trickster/Trickster.java
@@ -5,6 +5,7 @@ import dev.enjarai.trickster.config.TricksterConfig;
 import dev.enjarai.trickster.item.ModItems;
 import dev.enjarai.trickster.item.component.ModComponents;
 import dev.enjarai.trickster.item.recipe.ModRecipes;
+import dev.enjarai.trickster.misc.ModDamageTypes;
 import dev.enjarai.trickster.net.ModNetworking;
 import dev.enjarai.trickster.particle.ModParticles;
 import dev.enjarai.trickster.screen.ModScreenHandlers;
@@ -44,6 +45,7 @@ public class Trickster implements ModInitializer {
 		ModSounds.register();
 		ModAttachments.register();
 		ModRecipes.register();
+		ModDamageTypes.register();
 		Tricks.register();
 		SpellCircleEvent.register();
 	}

--- a/src/main/java/dev/enjarai/trickster/cca/ManaComponent.java
+++ b/src/main/java/dev/enjarai/trickster/cca/ManaComponent.java
@@ -1,11 +1,16 @@
 package dev.enjarai.trickster.cca;
 
 import dev.enjarai.trickster.entity.ModEntities;
+import dev.enjarai.trickster.misc.ModDamageTypes;
 import dev.enjarai.trickster.spell.ManaPool;
 import dev.enjarai.trickster.spell.SimpleManaPool;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.damage.DamageType;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.ladysnake.cca.api.v3.component.sync.AutoSyncedComponent;
@@ -66,10 +71,8 @@ public class ManaComponent extends SimpleManaPool implements AutoSyncedComponent
         float f = mana - amount;
         mana = Math.max(Math.min(mana - amount, maxMana), 0);
 
-        if (f < 0) { //TODO: funny death messages
-            if (!entity.isInCreativeMode())
-                entity.setHealth(entity.getHealth() - ManaPool.healthFromMana(f * -1));
-
+        if (f < 0) {
+            entity.damage(ModDamageTypes.of(entity.getWorld(), ModDamageTypes.MANA_OVERFLUX), ManaPool.healthFromMana(f * -1));
             return entity.isAlive();
         }
 

--- a/src/main/java/dev/enjarai/trickster/misc/ModDamageTypes.java
+++ b/src/main/java/dev/enjarai/trickster/misc/ModDamageTypes.java
@@ -1,0 +1,24 @@
+package dev.enjarai.trickster.misc;
+
+import dev.enjarai.trickster.Trickster;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.damage.DamageType;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.world.World;
+
+public class ModDamageTypes {
+    public static final RegistryKey<DamageType> MANA_OVERFLUX = register("mana_overflux");
+
+    public static DamageSource of(World world, RegistryKey<DamageType> key) {
+        return new DamageSource(world.getRegistryManager().get(RegistryKeys.DAMAGE_TYPE).entryOf(key));
+    }
+
+    private static RegistryKey<DamageType> register(String name) {
+        return RegistryKey.of(RegistryKeys.DAMAGE_TYPE, Trickster.id(name));
+    }
+
+    public static void register() {
+
+    }
+}

--- a/src/main/resources/assets/trickster/lang/en_us.yml
+++ b/src/main/resources/assets/trickster/lang/en_us.yml
@@ -156,6 +156,9 @@ tag.item.trickster:
   scrolls: Scrolls
   spell_cost: Spell Cost
 
+death.attack:
+  mana_overflux: "%1$s's magic show has met an untimely end."
+
 key:
   categories:
     trickster: Trickster

--- a/src/main/resources/data/minecraft/tags/damage_type/always_hurts_ender_dragons.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/always_hurts_ender_dragons.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trickster:mana_overflux"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/avoids_guardian_thorns.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/avoids_guardian_thorns.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trickster:mana_overflux"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_armor.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_armor.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trickster:mana_overflux"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_effects.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_effects.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trickster:mana_overflux"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_enchantments.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_enchantments.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trickster:mana_overflux"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_resistance.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_resistance.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trickster:mana_overflux"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_shield.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_shield.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trickster:mana_overflux"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/no_impact.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/no_impact.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trickster:mana_overflux"
+  ]
+}

--- a/src/main/resources/data/trickster/damage_type/mana_overflux.json
+++ b/src/main/resources/data/trickster/damage_type/mana_overflux.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.1,
+  "message_id": "mana_overflux",
+  "scaling": "never"
+}


### PR DESCRIPTION
When an entity runs out of mana, health would previously be deducted directly. However, this bypassed the entirety of the entity's damage handling, which reportedly made it so that *players killed by blood casting would not drop their items*. (The Discord message that got me writing this pull request: [enjarai's library](https://discord.com/channels/1016206797389975612/1254538231186456618/1261845478832869418))

This pull request rectifies these issues, and adds a silly death message for when someone messes up:
![image](https://github.com/user-attachments/assets/5b13d685-e2f2-480b-bd05-3ee8798fb337)
