### PR TITLE
Make spell scrolls behave more sanely

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ dependencies {
 
 	include modImplementation("org.ladysnake.cardinal-components-api:cardinal-components-base:${property('deps.cardinal-components-api')}")
 	include modImplementation("org.ladysnake.cardinal-components-api:cardinal-components-chunk:${property('deps.cardinal-components-api')}")
+	include modImplementation("org.ladysnake.cardinal-components-api:cardinal-components-world:${property('deps.cardinal-components-api')}")
 	include modImplementation("org.ladysnake.cardinal-components-api:cardinal-components-entity:${property('deps.cardinal-components-api')}")
 
 	modImplementation "com.terraformersmc:modmenu:${property('deps.modmenu')}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ deps.fabric-api=0.100.1+1.21
 deps.owo-lib=0.12.10+1.21
 deps.lavender=0.1.11+1.21
 deps.cicada=0.8.3+1.21-and-above
-deps.cardinal-components-api=6.1.0
+deps.cardinal-components-api=6.1.1
 deps.modmenu=11.0.1
 
 # Optional

--- a/src/client/java/dev/enjarai/trickster/mixin/client/figura/AvatarManagerMixin.java
+++ b/src/client/java/dev/enjarai/trickster/mixin/client/figura/AvatarManagerMixin.java
@@ -1,0 +1,37 @@
+package dev.enjarai.trickster.mixin.client.figura;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import dev.enjarai.trickster.cca.ModEntityCumponents;
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.UUID;
+
+@Pseudo
+@Mixin(targets = "org/figuramc/figura/avatar/AvatarManager")
+public class AvatarManagerMixin {
+    @Dynamic
+    @Inject(
+            method = "getAvatarForPlayer",
+            at = @At("HEAD")
+    )
+    private static void changeAvatarWhenPolymorphed(UUID uuid, CallbackInfoReturnable<Object> cir,
+                                                    @Local(argsOnly = true, index = 0) LocalRef<UUID> uuidRef) {
+        var world = MinecraftClient.getInstance().world;
+        if (world != null) {
+            var player = world.getPlayerByUuid(uuidRef.get());
+            if (player != null) {
+                var disguise = ModEntityCumponents.DISGUISE.get(player).getUuid();
+                if (disguise != null) {
+                    uuidRef.set(disguise);
+                }
+            }
+        }
+    }
+}

--- a/src/client/java/dev/enjarai/trickster/render/SpellCircleBlockEntityRenderer.java
+++ b/src/client/java/dev/enjarai/trickster/render/SpellCircleBlockEntityRenderer.java
@@ -2,6 +2,7 @@ package dev.enjarai.trickster.render;
 
 import dev.enjarai.trickster.block.SpellCircleBlock;
 import dev.enjarai.trickster.block.SpellCircleBlockEntity;
+import dev.enjarai.trickster.spell.SpellPart;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -94,7 +94,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                 // We're casting the big decimals down to doubles here, which means we're definitely not implementing
                 // infinite scrollability yet. We weren't using doubles in the renderer before though, so having that
                 // bit of extra precision might already make a big difference. If we actually do run into more issues,
-                // I *can* convert the renderer to big decimals as well, but that would result in an insane amount of
+                // I *can* convert the renderer to big decimals as well, but that would type in an insane amount of
                 // object allocations every frame, which could very well impact performance significantly.
                 x.doubleValue(), y.doubleValue(), size.doubleValue(), 0, delta,
                 size -> (float) Math.clamp(1 / (size / context.getScaledWindowHeight() * 2) - 0.2, 0, 1),

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -32,6 +32,8 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     public static final Pattern EXPAND_TO_OUTER_CIRCLE_GLYPH = Pattern.of(1, 2, 4, 6);
     public static final Pattern DELETE_CIRCLE_GLYPH = Pattern.of(0, 4, 8);
     public static final Pattern DELETE_BRANCH_GLYPH = Pattern.of(0, 4, 8, 5, 2, 1, 0, 3, 6, 7, 8);
+    public static final Pattern SHIFT_SUBCIRCLE_BACKWARDS_GLYPH = Pattern.of(1, 0, 3);
+    public static final Pattern SHIFT_SUBCIRCLE_FORWARDS_GLYPH = Pattern.of(1, 2, 5);
     public static final Pattern COPY_OFFHAND_LITERAL = Pattern.of(4, 0, 1, 4, 2, 1);
     public static final Pattern COPY_OFFHAND_LITERAL_INNER = Pattern.of(1, 2, 4, 1, 0, 4, 7);
     public static final Pattern COPY_OFFHAND_EXECUTE = Pattern.of(4, 3, 0, 4, 5, 2, 4, 1);
@@ -311,6 +313,12 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
             } else {
                 drawingPart.setSubPartInTree(Optional.empty(), spellPart, false);
             }
+        } else if (compiled.equals(SHIFT_SUBCIRCLE_BACKWARDS_GLYPH)) {
+            if (!drawingPart.subParts.isEmpty())
+                drawingPart.subParts.add(drawingPart.subParts.removeFirst());
+        } else if (compiled.equals(SHIFT_SUBCIRCLE_FORWARDS_GLYPH)) {
+            if (!drawingPart.subParts.isEmpty())
+                drawingPart.subParts.addFirst(drawingPart.subParts.removeLast());
         } else if (compiled.equals(COPY_OFFHAND_LITERAL)) {
             if (drawingPart == spellPart) {
                 spellPart = otherHandSpellSupplier.get().deepClone();

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -94,7 +94,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                 // We're casting the big decimals down to doubles here, which means we're definitely not implementing
                 // infinite scrollability yet. We weren't using doubles in the renderer before though, so having that
                 // bit of extra precision might already make a big difference. If we actually do run into more issues,
-                // I *can* convert the renderer to big decimals as well, but that would type in an insane amount of
+                // I *can* convert the renderer to big decimals as well, but that would result in an insane amount of
                 // object allocations every frame, which could very well impact performance significantly.
                 x.doubleValue(), y.doubleValue(), size.doubleValue(), 0, delta,
                 size -> (float) Math.clamp(1 / (size / context.getScaledWindowHeight() * 2) - 0.2, 0, 1),

--- a/src/client/resources/trickster.client.mixins.json
+++ b/src/client/resources/trickster.client.mixins.json
@@ -15,7 +15,8 @@
     "WorldRendererAccessor",
     "accessories.AccessoriesScreenMixin",
     "sodium.WorldSliceMixin",
-    "tooltip.TooltipComponentMixin"
+    "tooltip.TooltipComponentMixin",
+    "figura.AvatarManagerMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/java/dev/enjarai/trickster/ConditionalMixins.java
+++ b/src/main/java/dev/enjarai/trickster/ConditionalMixins.java
@@ -16,7 +16,8 @@ public class ConditionalMixins implements IMixinConfigPlugin {
     private static final Supplier<Boolean> TRUE = () -> true;
 
     private static final Map<String, Supplier<Boolean>> CONDITIONS = ImmutableMap.of(
-            "dev.enjarai.trickster.mixin.client.sodium.WorldSliceMixin", () -> FabricLoader.getInstance().isModLoaded("sodium")
+            "dev.enjarai.trickster.mixin.client.sodium.WorldSliceMixin", () -> FabricLoader.getInstance().isModLoaded("sodium"),
+            "dev.enjarai.trickster.mixin.client.figura.AvatarManagerMixin", () -> FabricLoader.getInstance().isModLoaded("figura")
     );
 
     @Override

--- a/src/main/java/dev/enjarai/trickster/block/SpellCircleBlockEntity.java
+++ b/src/main/java/dev/enjarai/trickster/block/SpellCircleBlockEntity.java
@@ -120,7 +120,7 @@ public class SpellCircleBlockEntity extends BlockEntity {
     public void tick() {
         manaPool.stdIncrease();
 
-        if (event.isMultiTick() && !getWorld().isClient()) {
+        if (event.isMultiTick() && !getWorld().isClient() && executor != null) {
             if (spellSource == null) {
                 spellSource = new BlockSpellSource((ServerWorld) getWorld(), getPos(), this);
             }
@@ -136,6 +136,8 @@ public class SpellCircleBlockEntity extends BlockEntity {
                 lastError = Text.literal("Uncaught exception in spell: " + e.getMessage())
                         .append(" (").append(executor.getCurrentState().formatStackTrace()).append(")");
             }
+
+            markDirty();
         }
         age++;
     }

--- a/src/main/java/dev/enjarai/trickster/cca/CasterComponent.java
+++ b/src/main/java/dev/enjarai/trickster/cca/CasterComponent.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.DataResult;
 import dev.enjarai.trickster.ModSounds;
 import dev.enjarai.trickster.spell.Fragment;
 import dev.enjarai.trickster.spell.SpellPart;
+import dev.enjarai.trickster.spell.execution.SpellQueueResult;
 import dev.enjarai.trickster.spell.execution.executor.ErroredSpellExecutor;
 import dev.enjarai.trickster.spell.execution.executor.SpellExecutor;
 import dev.enjarai.trickster.spell.execution.source.PlayerSpellSource;
@@ -134,14 +135,14 @@ public class CasterComponent implements ServerTickingComponent, AutoSyncedCompon
         buf.write(SPELL_DATA_ENDEC, runningSpellData);
     }
 
-    public boolean queueAndCast(SpellPart spell, List<Fragment> arguments) {
+    public boolean queueSpell(SpellPart spell, List<Fragment> arguments) {
         playCastSound(0.8f, 0.1f);
         return executionManager.queue(spell, arguments);
     }
 
-    public boolean queueAndCast(SpellPart spell, List<Fragment> arguments, ManaPool poolOverride) {
+    public SpellQueueResult queueSpellAndCast(SpellPart spell, List<Fragment> arguments, ManaPool poolOverride) {
         playCastSound(0.8f, 0.1f);
-        return executionManager.queue(spell, arguments, poolOverride);
+        return executionManager.queueAndCast(spell, arguments, poolOverride);
     }
 
     public void killAll() {

--- a/src/main/java/dev/enjarai/trickster/cca/ModWorldCumponents.java
+++ b/src/main/java/dev/enjarai/trickster/cca/ModWorldCumponents.java
@@ -1,0 +1,17 @@
+package dev.enjarai.trickster.cca;
+
+import dev.enjarai.trickster.Trickster;
+import org.ladysnake.cca.api.v3.component.ComponentKey;
+import org.ladysnake.cca.api.v3.component.ComponentRegistry;
+import org.ladysnake.cca.api.v3.world.WorldComponentFactoryRegistry;
+import org.ladysnake.cca.api.v3.world.WorldComponentInitializer;
+
+public class ModWorldCumponents implements WorldComponentInitializer {
+    public static final ComponentKey<PinnedChunksComponent> PINNED_CHUNKS =
+            ComponentRegistry.getOrCreate(Trickster.id("pinned_chunks"), PinnedChunksComponent.class);
+
+    @Override
+    public void registerWorldComponentFactories(WorldComponentFactoryRegistry registry) {
+        registry.register(PINNED_CHUNKS, PinnedChunksComponent::new);
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/cca/PinnedChunksComponent.java
+++ b/src/main/java/dev/enjarai/trickster/cca/PinnedChunksComponent.java
@@ -59,6 +59,10 @@ public class PinnedChunksComponent implements ServerTickingComponent {
         serverWorld.getChunkManager().addTicket(TICKET_TYPE, pos, 1, pos);
     }
 
+    public boolean isPinned(ChunkPos pos) {
+        return pins.containsKey(pos.toLong());
+    }
+
     public void pinThemAll() {
         // This means a server reboot will pin chunks for slightly longer than normal,
         // but that shouldn't be an issue in practice.

--- a/src/main/java/dev/enjarai/trickster/cca/PinnedChunksComponent.java
+++ b/src/main/java/dev/enjarai/trickster/cca/PinnedChunksComponent.java
@@ -1,0 +1,70 @@
+package dev.enjarai.trickster.cca;
+
+import io.wispforest.endec.Endec;
+import io.wispforest.endec.impl.KeyedEndec;
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.server.world.ChunkTicketType;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import org.ladysnake.cca.api.v3.component.tick.ServerTickingComponent;
+
+import java.util.Comparator;
+import java.util.Map;
+
+public class PinnedChunksComponent implements ServerTickingComponent {
+    public static final KeyedEndec<Map<Long, Integer>> PINS_ENDEC =
+            Endec.map(Endec.LONG, Endec.INT).keyed("pins", Map.of());
+    public static final ChunkTicketType<ChunkPos> TICKET_TYPE =
+            ChunkTicketType.create("trickster:pinned", Comparator.comparingLong(ChunkPos::toLong), 80);
+
+    private final World world;
+    private final Long2IntMap pins = new Long2IntOpenHashMap();
+
+    public PinnedChunksComponent(World world) {
+        this.world = world;
+    }
+
+    @Override
+    public void serverTick() {
+        pins.keySet().forEach(chunk -> pins.compute(chunk, (c, t) -> t <= 0 ? null : t - 1));
+        if (!pins.isEmpty()) {
+            ((ServerWorld) world).resetIdleTimeout();
+        }
+    }
+
+    @Override
+    public void readFromNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
+        pins.clear();
+        pins.putAll(tag.get(PINS_ENDEC));
+    }
+
+    @Override
+    public void writeToNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
+        tag.put(PINS_ENDEC, pins);
+    }
+
+    /**
+     * Pin a specific chunk for 80 ticks.
+     */
+    public void pinChunk(ChunkPos pos) {
+        if (!(world instanceof ServerWorld serverWorld)) {
+            throw new IllegalStateException("Can only pin chunks on logical server");
+        }
+
+        pins.put(pos.toLong(), 80);
+        serverWorld.getChunkManager().addTicket(TICKET_TYPE, pos, 1, pos);
+    }
+
+    public void pinThemAll() {
+        // This means a server reboot will pin chunks for slightly longer than normal,
+        // but that shouldn't be an issue in practice.
+        pins.keySet().forEach(chunk -> {
+            var pos = new ChunkPos(chunk);
+            ((ServerWorld) world).getChunkManager().addTicket(TICKET_TYPE, pos, 1, pos);
+        });
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/item/WandItem.java
+++ b/src/main/java/dev/enjarai/trickster/item/WandItem.java
@@ -23,7 +23,7 @@ public class WandItem extends Item {
         if (!world.isClient()) {
             var spell = stack.get(ModComponents.SPELL);
             if (spell != null) {
-                user.getComponent(ModEntityCumponents.CASTER).queueAndCast(spell.spell(), List.of());
+                user.getComponent(ModEntityCumponents.CASTER).queueSpell(spell.spell(), List.of());
             }
         }
 

--- a/src/main/java/dev/enjarai/trickster/item/WrittenScrollItem.java
+++ b/src/main/java/dev/enjarai/trickster/item/WrittenScrollItem.java
@@ -3,6 +3,7 @@ package dev.enjarai.trickster.item;
 import dev.enjarai.trickster.cca.ModEntityCumponents;
 import dev.enjarai.trickster.item.component.ModComponents;
 import dev.enjarai.trickster.screen.ScrollAndQuillScreenHandler;
+import dev.enjarai.trickster.spell.execution.SpellQueueResult;
 import dev.enjarai.trickster.spell.mana.SimpleManaPool;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
@@ -38,7 +39,9 @@ public class WrittenScrollItem extends Item {
             if (!world.isClient()) {
                 var spell = stack.get(ModComponents.SPELL);
                 if (spell != null) {
-                    if (ModEntityCumponents.CASTER.get(user).queueAndCast(spell.spell(), List.of(), SimpleManaPool.getSingleUse(meta.mana())))
+                    var result = ModEntityCumponents.CASTER.get(user).queueSpellAndCast(spell.spell(), List.of(), SimpleManaPool.getSingleUse(meta.mana()));
+
+                    if (result.type() != SpellQueueResult.Type.NOT_QUEUED && result.state().hasUsedMana())
                         stack.decrement(1);
                     return TypedActionResult.success(stack);
                 }

--- a/src/main/java/dev/enjarai/trickster/mixin/chunk_pinning/MinecraftServerMixin.java
+++ b/src/main/java/dev/enjarai/trickster/mixin/chunk_pinning/MinecraftServerMixin.java
@@ -1,0 +1,25 @@
+package dev.enjarai.trickster.mixin.chunk_pinning;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.enjarai.trickster.cca.ModWorldCumponents;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.WorldGenerationProgressListener;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+    @Inject(
+            method = "prepareStartRegion",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/world/ServerWorld;getPersistentStateManager()Lnet/minecraft/world/PersistentStateManager;"
+            )
+    )
+    private void loadPinChunks(WorldGenerationProgressListener worldGenerationProgressListener, CallbackInfo ci, @Local(ordinal = 1) ServerWorld serverWorld) {
+        ModWorldCumponents.PINNED_CHUNKS.get(serverWorld).pinThemAll();
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/mixin/chunk_pinning/ServerChunkLoadingManagerMixin.java
+++ b/src/main/java/dev/enjarai/trickster/mixin/chunk_pinning/ServerChunkLoadingManagerMixin.java
@@ -1,0 +1,29 @@
+package dev.enjarai.trickster.mixin.chunk_pinning;
+
+import dev.enjarai.trickster.cca.ModWorldCumponents;
+import net.minecraft.server.world.ServerChunkLoadingManager;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ChunkPos;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerChunkLoadingManager.class)
+public class ServerChunkLoadingManagerMixin {
+    @Shadow @Final
+    ServerWorld world;
+
+    @Inject(
+            method = "shouldTick",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void enableTicksFromWorldPin(ChunkPos pos, CallbackInfoReturnable<Boolean> cir) {
+        if (ModWorldCumponents.PINNED_CHUNKS.get(world).isPinned(pos)) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/mixin/chunk_pinning/ServerWorldMixin.java
+++ b/src/main/java/dev/enjarai/trickster/mixin/chunk_pinning/ServerWorldMixin.java
@@ -1,0 +1,36 @@
+package dev.enjarai.trickster.mixin.chunk_pinning;
+
+import dev.enjarai.trickster.cca.ModWorldCumponents;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.profiler.Profiler;
+import net.minecraft.world.MutableWorldProperties;
+import net.minecraft.world.World;
+import net.minecraft.world.dimension.DimensionType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Supplier;
+
+@Mixin(ServerWorld.class)
+public abstract class ServerWorldMixin extends World {
+    protected ServerWorldMixin(MutableWorldProperties properties, RegistryKey<World> registryRef, DynamicRegistryManager registryManager, RegistryEntry<DimensionType> dimensionEntry, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long biomeAccess, int maxChainedNeighborUpdates) {
+        super(properties, registryRef, registryManager, dimensionEntry, profiler, isClient, debugWorld, biomeAccess, maxChainedNeighborUpdates);
+    }
+
+    @Inject(
+            method = "shouldTick(Lnet/minecraft/util/math/ChunkPos;)Z",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void worldPinTick(ChunkPos pos, CallbackInfoReturnable<Boolean> cir) {
+        if (ModWorldCumponents.PINNED_CHUNKS.get(this).isPinned(pos)) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/screen/ScrollAndQuillScreenHandler.java
+++ b/src/main/java/dev/enjarai/trickster/screen/ScrollAndQuillScreenHandler.java
@@ -117,8 +117,8 @@ public class ScrollAndQuillScreenHandler extends ScreenHandler {
                     });
                 }
             } else {
-//            var type = SpellPart.CODEC.encodeStart(JsonOps.INSTANCE, spell).type().get();
-//            Trickster.LOGGER.warn(type.toString());
+//            var result = SpellPart.CODEC.encodeStart(JsonOps.INSTANCE, spell).result().get();
+//            Trickster.LOGGER.warn(result.toString());
                 sendMessage(new SpellMessage(spell));
             }
         }

--- a/src/main/java/dev/enjarai/trickster/screen/ScrollAndQuillScreenHandler.java
+++ b/src/main/java/dev/enjarai/trickster/screen/ScrollAndQuillScreenHandler.java
@@ -117,8 +117,8 @@ public class ScrollAndQuillScreenHandler extends ScreenHandler {
                     });
                 }
             } else {
-//            var result = SpellPart.CODEC.encodeStart(JsonOps.INSTANCE, spell).result().get();
-//            Trickster.LOGGER.warn(result.toString());
+//            var type = SpellPart.CODEC.encodeStart(JsonOps.INSTANCE, spell).type().get();
+//            Trickster.LOGGER.warn(type.toString());
                 sendMessage(new SpellMessage(spell));
             }
         }

--- a/src/main/java/dev/enjarai/trickster/spell/ItemTriggerProvider.java
+++ b/src/main/java/dev/enjarai/trickster/spell/ItemTriggerProvider.java
@@ -38,7 +38,7 @@ public interface ItemTriggerProvider {
         var spellComponent = stack.get(ModComponents.SPELL);
 
         if (spellComponent != null) {
-            ModEntityCumponents.CASTER.get(player).queueAndCast(spellComponent.spell(), arguments);
+            ModEntityCumponents.CASTER.get(player).queueSpell(spellComponent.spell(), arguments);
         }
     }
 }

--- a/src/main/java/dev/enjarai/trickster/spell/execution/ExecutionState.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/ExecutionState.java
@@ -23,24 +23,27 @@ public class ExecutionState {
             Codec.INT.fieldOf("recursions").forGetter(ExecutionState::getRecursions),
             Codec.INT.fieldOf("delay").forGetter(ExecutionState::getDelay),
             Codec.BOOL.fieldOf("has_used_mana").forGetter(ExecutionState::hasUsedMana),
+            Codec.INT.fieldOf("stacktrace_size_when_made").forGetter(ExecutionState::getInitialStacktraceSize),
             Fragment.CODEC.get().codec().listOf().fieldOf("arguments").forGetter(state -> state.arguments),
             Codec.INT.listOf().fieldOf("stacktrace").forGetter(state -> state.stacktrace.stream().toList()),
             ManaLink.CODEC.listOf().fieldOf("mana_links").forGetter(state -> state.manaLinks),
             ManaPool.CODEC.get().codec().optionalFieldOf("pool_override").forGetter(state -> state.poolOverride)
     ).apply(instance, ExecutionState::new));
 
-    protected int recursions;
-    protected int delay;
-    private boolean hasUsedMana = false;
+    private int recursions;
+    private int delay;
+    private boolean hasUsedMana;
+    private final int initialStacktraceSize;
     private final List<Fragment> arguments;
     private final Deque<Integer> stacktrace = new ArrayDeque<>();
     private final List<ManaLink> manaLinks = new ArrayList<>();
     private final Optional<ManaPool> poolOverride;
 
-    private ExecutionState(int recursions, int delay, boolean hasUsedMana, List<Fragment> arguments, List<Integer> stacktrace, List<ManaLink> manaLinks, Optional<ManaPool> poolOverride) {
+    private ExecutionState(int recursions, int delay, boolean hasUsedMana, int initialStacktraceSize, List<Fragment> arguments, List<Integer> stacktrace, List<ManaLink> manaLinks, Optional<ManaPool> poolOverride) {
         this.recursions = recursions;
         this.delay = delay;
         this.hasUsedMana = hasUsedMana;
+        this.initialStacktraceSize = initialStacktraceSize;
         this.arguments = arguments;
         this.stacktrace.addAll(stacktrace);
         this.manaLinks.addAll(manaLinks);
@@ -48,15 +51,15 @@ public class ExecutionState {
     }
 
     public ExecutionState(List<Fragment> arguments) {
-        this(0, 0, false, arguments, List.of(), List.of(), Optional.empty());
+        this(0, 0, false, 0, arguments, List.of(), List.of(), Optional.empty());
     }
 
     public ExecutionState(List<Fragment> arguments, ManaPool poolOverride) {
-        this(0, 0, false, arguments, List.of(), List.of(), Optional.ofNullable(poolOverride));
+        this(0, 0, false, 0, arguments, List.of(), List.of(), Optional.ofNullable(poolOverride));
     }
 
-    private ExecutionState(int recursions, List<Fragment> arguments, Optional<ManaPool> poolOverride) {
-        this(recursions, 0, false, arguments, List.of(), List.of(), poolOverride);
+    private ExecutionState(int recursions, List<Fragment> arguments, Optional<ManaPool> poolOverride, Deque<Integer> stacktrace) {
+        this(recursions, 0, false, stacktrace.size(), arguments, stacktrace.stream().toList(), List.of(), poolOverride);
     }
 
     public ExecutionState recurseOrThrow(List<Fragment> arguments) throws ExecutionLimitReachedBlunder {
@@ -64,8 +67,7 @@ public class ExecutionState {
             throw new ExecutionLimitReachedBlunder();
         }
 
-        var state = new ExecutionState(recursions + 1, arguments, poolOverride);
-        state.stacktrace.addAll(stacktrace);
+        var state = new ExecutionState(recursions + 1, arguments, poolOverride, stacktrace);
         state.stacktrace.push(-2);
         return state;
     }
@@ -74,10 +76,12 @@ public class ExecutionState {
         recursions--;
         // Remove the function call instruction that was added by recursing from the stacktrace,
         // and add a tail recursion one instead.
-        stacktrace.pop();
-        if (stacktrace.isEmpty() || stacktrace.peek() != -3) {
-            stacktrace.push(-3);
+        while (!stacktrace.isEmpty() && stacktrace.size() >= initialStacktraceSize) {
+            stacktrace.pop();
         }
+
+        if (stacktrace.isEmpty() || stacktrace.peek() != -3)
+            stacktrace.push(-3);
     }
 
     public ManaPool tryOverridePool(ManaPool pool) {
@@ -145,6 +149,10 @@ public class ExecutionState {
 
     public Deque<Integer> getStacktrace() {
         return stacktrace;
+    }
+
+    public int getInitialStacktraceSize() {
+        return initialStacktraceSize;
     }
 
     public void addManaLink(Trick trickSource, LivingEntity target, float ownerHealth, float limit) throws BlunderException {

--- a/src/main/java/dev/enjarai/trickster/spell/execution/SpellExecutionManager.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/SpellExecutionManager.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class SpellExecutionManager {
     public static final Codec<SpellExecutionManager> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.INT.optionalFieldOf("capacity", 5).forGetter(e -> e.capacity),
-            Codec.unboundedMap(Codec.STRING.xmap(Integer::parseInt, Object::toString), SpellExecutor.CODEC.get().codec())
+            Codec.unboundedMap(Codec.STRING.xmap(Integer::parseInt, Object::toString), SpellExecutor.CODEC.get())
                     .fieldOf("spells").forGetter((e) -> e.spells)
     ).apply(instance, SpellExecutionManager::new));
 

--- a/src/main/java/dev/enjarai/trickster/spell/execution/SpellExecutionManager.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/SpellExecutionManager.java
@@ -17,6 +17,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.text.Text;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SpellExecutionManager {
     public static final Codec<SpellExecutionManager> CODEC = RecordCodecBuilder.create(instance -> instance.group(
@@ -44,8 +45,28 @@ public class SpellExecutionManager {
         return queue(new DefaultSpellExecutor(spell, arguments));
     }
 
-    public boolean queue(SpellPart spell, List<Fragment> arguments, ManaPool poolOverride) {
-        return queue(new DefaultSpellExecutor(spell, new ExecutionState(arguments, poolOverride)));
+    public SpellQueueResult queueAndCast(SpellPart spell, List<Fragment> arguments, ManaPool poolOverride) {
+        var executor = new DefaultSpellExecutor(spell, new ExecutionState(arguments, poolOverride));
+        boolean queued = queue(executor);
+
+        if (queued) {
+            for (var iterator = spells.int2ObjectEntrySet().iterator(); iterator.hasNext();) {
+                var entry = iterator.next();
+
+                if (entry.getValue() == executor) {
+                    AtomicBoolean isDone = new AtomicBoolean(true);
+                    tryRun(entry,
+                            (index, executor1) -> isDone.set(false),
+                            (index, executor2) -> iterator.remove(),
+                            (index, executor3) -> { });
+                    return new SpellQueueResult(isDone.get()
+                            ? SpellQueueResult.Type.QUEUED_DONE
+                            : SpellQueueResult.Type.QUEUED_STILL_RUNNING, executor.getCurrentState());
+                }
+            }
+        }
+
+        return new SpellQueueResult(SpellQueueResult.Type.NOT_QUEUED, executor.getCurrentState());
     }
 
     public boolean queue(SpellExecutor executor) {
@@ -67,36 +88,54 @@ public class SpellExecutionManager {
         if (source == null)
             return;
 
-        for (var iterator = spells.int2ObjectEntrySet().iterator(); iterator.hasNext(); ) {
+        for (var iterator = spells.int2ObjectEntrySet().iterator(); iterator.hasNext();) {
             var entry = iterator.next();
-            var spell = entry.getValue();
-
-            try {
-                if (spell.run(source).isEmpty()) {
-                    tickCallback.callTheBack(entry.getIntKey(), spell);
-                } else {
-                    iterator.remove();
-                    completeCallback.callTheBack(entry.getIntKey(), spell);
-                }
-            } catch (BlunderException blunder) {
-                var message = blunder.createMessage()
-                        .append(" (").append(spell.getCurrentState().formatStackTrace()).append(")");
-
-                if (blunder instanceof NaNBlunder)
-                    source.getPlayer().ifPresent(ModCriteria.NAN_NUMBER::trigger);
-
-                entry.setValue(new ErroredSpellExecutor(message));
-                source.getPlayer().ifPresent(player -> player.sendMessage(message));
-                errorCallback.callTheBack(entry.getIntKey(), spell);
-            } catch (Exception e) {
-                var message = Text.literal("Uncaught exception in spell: " + e.getMessage())
-                        .append(" (").append(spell.getCurrentState().formatStackTrace()).append(")");
-
-                entry.setValue(new ErroredSpellExecutor(message));
-                source.getPlayer().ifPresent(player -> player.sendMessage(message));
-                errorCallback.callTheBack(entry.getIntKey(), spell);
-            }
+            tryRun(entry, tickCallback, (index, executor) -> {
+                iterator.remove();
+                completeCallback.callTheBack(index, executor);
+            }, errorCallback);
         }
+    }
+
+    /**
+     * Attempts to run the given entry's SpellExecutor.
+     * @param entry
+     * @param tickCallback
+     * @param completeCallback
+     * @param errorCallback
+     * @return whether the spell has finished running or not. Blunders and normal completion return true, otherwise returns false.
+     */
+    private boolean tryRun(Int2ObjectMap.Entry<SpellExecutor> entry, ExecutorCallback tickCallback, ExecutorCallback completeCallback, ExecutorCallback errorCallback) {
+        var spell = entry.getValue();
+
+        try {
+            if (spell.run(source).isEmpty()) {
+                tickCallback.callTheBack(entry.getIntKey(), spell);
+                return false;
+            } else {
+                completeCallback.callTheBack(entry.getIntKey(), spell);
+                return true;
+            }
+        } catch (BlunderException blunder) {
+            var message = blunder.createMessage()
+                    .append(" (").append(spell.getCurrentState().formatStackTrace()).append(")");
+
+            if (blunder instanceof NaNBlunder)
+                source.getPlayer().ifPresent(ModCriteria.NAN_NUMBER::trigger);
+
+            entry.setValue(new ErroredSpellExecutor(message));
+            source.getPlayer().ifPresent(player -> player.sendMessage(message));
+            errorCallback.callTheBack(entry.getIntKey(), spell);
+        } catch (Exception e) {
+            var message = Text.literal("Uncaught exception in spell: " + e.getMessage())
+                    .append(" (").append(spell.getCurrentState().formatStackTrace()).append(")");
+
+            entry.setValue(new ErroredSpellExecutor(message));
+            source.getPlayer().ifPresent(player -> player.sendMessage(message));
+            errorCallback.callTheBack(entry.getIntKey(), spell);
+        }
+
+        return true;
     }
 
     public void setSource(SpellSource source) {

--- a/src/main/java/dev/enjarai/trickster/spell/execution/SpellQueueResult.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/SpellQueueResult.java
@@ -1,0 +1,9 @@
+package dev.enjarai.trickster.spell.execution;
+
+public record SpellQueueResult(Type type, ExecutionState state) {
+    public enum Type {
+        NOT_QUEUED,
+        QUEUED_DONE,
+        QUEUED_STILL_RUNNING
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/DefaultSpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/DefaultSpellExecutor.java
@@ -23,7 +23,7 @@ public class DefaultSpellExecutor implements SpellExecutor {
             Codec.list(Fragment.CODEC.get().codec()).fieldOf("inputs").forGetter(executor -> executor.inputs),
             Codec.list(Codec.INT).fieldOf("scope").forGetter(executor -> executor.scope),
             ExecutionState.CODEC.fieldOf("state").forGetter(executor -> executor.state),
-            SpellExecutor.CODEC.get().codec().optionalFieldOf("child").forGetter(executor -> executor.child),
+            SpellExecutor.CODEC.get().optionalFieldOf("child").forGetter(executor -> executor.child),
             Fragment.CODEC.get().codec().optionalFieldOf("override_return_value").forGetter(executor -> executor.overrideReturnValue)
     ).apply(instance, (instructions, inputs, scope, state, child, overrideReturnValue) -> {
         List<SpellInstruction> serializedInstructions = instructions.stream().map(SerializedSpellInstruction::toDeserialized).collect(Collectors.toList());

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/DefaultSpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/DefaultSpellExecutor.java
@@ -93,7 +93,7 @@ public class DefaultSpellExecutor implements SpellExecutor {
     }
 
     /**
-     * @return the spell's type, or Optional.empty() if the spell is not done executing.
+     * @return the spell's result, or Optional.empty() if the spell is not done executing.
      * @throws BlunderException
      */
     @Override
@@ -102,7 +102,7 @@ public class DefaultSpellExecutor implements SpellExecutor {
     }
 
     /**
-     * @return the spell's type, or Optional.empty() if the spell is not done executing.
+     * @return the spell's result, or Optional.empty() if the spell is not done executing.
      * @throws BlunderException
      */
     protected Optional<Fragment> run(SpellContext ctx, int executions) throws BlunderException {

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/IteratorSpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/IteratorSpellExecutor.java
@@ -23,7 +23,7 @@ public class IteratorSpellExecutor extends DefaultSpellExecutor {
             ListFragment.CODEC.codec().fieldOf("list").forGetter(executor -> executor.list),
             Codec.list(Fragment.CODEC.get().codec()).fieldOf("inputs").forGetter(executor -> executor.inputs),
             ExecutionState.CODEC.fieldOf("state").forGetter(executor -> executor.state),
-            SpellExecutor.CODEC.get().codec().optionalFieldOf("child").forGetter(executor -> executor.child)
+            SpellExecutor.CODEC.get().optionalFieldOf("child").forGetter(executor -> executor.child)
     ).apply(instance, IteratorSpellExecutor::new)));
 
     protected final SpellPart executable;

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/SpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/SpellExecutor.java
@@ -2,6 +2,7 @@ package dev.enjarai.trickster.spell.execution.executor;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import dev.enjarai.trickster.spell.Fragment;
 import dev.enjarai.trickster.spell.SpellContext;
@@ -13,7 +14,8 @@ import dev.enjarai.trickster.spell.trick.blunder.ExecutionLimitReachedBlunder;
 import java.util.Optional;
 
 public interface SpellExecutor {
-    Supplier<MapCodec<SpellExecutor>> CODEC = Suppliers.memoize(() -> SpellExecutorType.REGISTRY.getCodec().dispatchMap(SpellExecutor::type, SpellExecutorType::codec));
+    Supplier<MapCodec<SpellExecutor>> MAP_CODEC = Suppliers.memoize(() -> SpellExecutorType.REGISTRY.getCodec().dispatchMap(SpellExecutor::type, SpellExecutorType::codec));
+    Supplier<Codec<SpellExecutor>> CODEC = Suppliers.memoize(() -> MAP_CODEC.get().codec());
 
     SpellExecutorType<?> type();
 

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/SpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/SpellExecutor.java
@@ -22,7 +22,7 @@ public interface SpellExecutor {
      * <p>
      * Before this function throws, it will append the additional spell stacktrace to the stacktrace in the provided context.
      *
-     * @return the spell's result.
+     * @return the spell's type.
      * @throws BlunderException
      */
     default Fragment singleTickRun(SpellContext context) throws BlunderException {
@@ -38,7 +38,7 @@ public interface SpellExecutor {
     /**
      * Attempts to execute the spell within a single tick, throws ExecutionLimitReachedBlunder if single-tick execution is not feasible.
      *
-     * @return the spell's result.
+     * @return the spell's type.
      * @throws BlunderException
      */
     default Fragment singleTickRun(SpellSource source) throws BlunderException {
@@ -46,7 +46,7 @@ public interface SpellExecutor {
     }
 
     /**
-     * @return the spell's result, or Optional.empty() if the spell is not done executing.
+     * @return the spell's type, or Optional.empty() if the spell is not done executing.
      * @throws BlunderException
      */
     default Optional<Fragment> run(SpellSource source) throws BlunderException {
@@ -54,7 +54,7 @@ public interface SpellExecutor {
     }
 
     /**
-     * @return the spell's result, or Optional.empty() if the spell is not done executing.
+     * @return the spell's type, or Optional.empty() if the spell is not done executing.
      * @throws BlunderException
      */
     Optional<Fragment> run(SpellSource source, int executions) throws BlunderException;

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/SpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/SpellExecutor.java
@@ -22,7 +22,7 @@ public interface SpellExecutor {
      * <p>
      * Before this function throws, it will append the additional spell stacktrace to the stacktrace in the provided context.
      *
-     * @return the spell's type.
+     * @return the spell's result.
      * @throws BlunderException
      */
     default Fragment singleTickRun(SpellContext context) throws BlunderException {
@@ -38,7 +38,7 @@ public interface SpellExecutor {
     /**
      * Attempts to execute the spell within a single tick, throws ExecutionLimitReachedBlunder if single-tick execution is not feasible.
      *
-     * @return the spell's type.
+     * @return the spell's result.
      * @throws BlunderException
      */
     default Fragment singleTickRun(SpellSource source) throws BlunderException {
@@ -46,7 +46,7 @@ public interface SpellExecutor {
     }
 
     /**
-     * @return the spell's type, or Optional.empty() if the spell is not done executing.
+     * @return the spell's result, or Optional.empty() if the spell is not done executing.
      * @throws BlunderException
      */
     default Optional<Fragment> run(SpellSource source) throws BlunderException {
@@ -54,7 +54,7 @@ public interface SpellExecutor {
     }
 
     /**
-     * @return the spell's type, or Optional.empty() if the spell is not done executing.
+     * @return the spell's result, or Optional.empty() if the spell is not done executing.
      * @throws BlunderException
      */
     Optional<Fragment> run(SpellSource source, int executions) throws BlunderException;

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/TryCatchSpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/TryCatchSpellExecutor.java
@@ -16,8 +16,8 @@ import java.util.Optional;
 public class TryCatchSpellExecutor extends DefaultSpellExecutor {
     public static final MapCodec<TryCatchSpellExecutor> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance.group(
             DefaultSpellExecutor.CODEC.codec().fieldOf("self").forGetter(executor -> executor),
-            SpellExecutor.CODEC.get().fieldOf("try").forGetter(executor -> executor.trySpell),
-            SpellExecutor.CODEC.get().fieldOf("catch").forGetter(executor -> executor.catchSpell),
+            SpellExecutor.MAP_CODEC.get().fieldOf("try").forGetter(executor -> executor.trySpell),
+            SpellExecutor.MAP_CODEC.get().fieldOf("catch").forGetter(executor -> executor.catchSpell),
             Codec.BOOL.fieldOf("catching").forGetter(executor -> executor.catching)
     ).apply(instance, (self, trySpell, catchSpell, catching) -> new TryCatchSpellExecutor(self.instructions, self.inputs, self.scope, self.state, self.child, self.overrideReturnValue, trySpell, catchSpell, catching)));
 

--- a/src/main/java/dev/enjarai/trickster/spell/fragment/SlotFragment.java
+++ b/src/main/java/dev/enjarai/trickster/spell/fragment/SlotFragment.java
@@ -42,14 +42,18 @@ public record SlotFragment(int slot, Optional<BlockPos> source) implements Fragm
         return move(trickSource, ctx, 1);
     }
 
-    public ItemStack move(Trick trickSource, SpellContext ctx, int amount) throws BlunderException {
+    public ItemStack move(Trick trickSource, SpellContext ctx, int amount) {
+        return move(trickSource, ctx, amount, ctx.source().getBlockPos());
+    }
+
+    public ItemStack move(Trick trickSource, SpellContext ctx, int amount, BlockPos pos) throws BlunderException {
         var stack = getStack(trickSource, ctx);
 
         if (stack.getCount() < amount)
             throw new MissingItemBlunder(trickSource);
 
         var result = stack.copyWithCount(amount);
-        source.ifPresent(pos -> ctx.useMana(trickSource, (float) (amount * (32 + (ctx.source().getBlockPos().toCenterPos().distanceTo(pos.toCenterPos()) * 0.8)))));
+        source.ifPresent(sourcePos -> ctx.useMana(trickSource, (float) (amount * (32 + (pos.toCenterPos().distanceTo(sourcePos.toCenterPos()) * 0.8)))));
         stack.decrement(amount);
         return result;
     }

--- a/src/main/java/dev/enjarai/trickster/spell/trick/Tricks.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/Tricks.java
@@ -181,6 +181,7 @@ public class Tricks {
     public static final OtherHandTrick OTHER_HAND = register("other_hand", new OtherHandTrick());
     public static final GetItemInSlotTrick GET_ITEM_IN_SLOT = register("get_item_in_slot", new GetItemInSlotTrick());
     public static final GetInventorySlotTrick GET_INVENTORY_SLOT = register("get_inventory_slot", new GetInventorySlotTrick());
+    public static final DropStackFromSlotTrick DROP_STACK_FROM_SLOT = register("drop_stack_from_slot", new DropStackFromSlotTrick());
 
     // Projectile
     public static final SummonArrowTrick SUMMON_ARROW = register("summon_arrow", new SummonArrowTrick());

--- a/src/main/java/dev/enjarai/trickster/spell/trick/Tricks.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/Tricks.java
@@ -14,10 +14,7 @@ import dev.enjarai.trickster.spell.trick.event.DeleteSpellCircleTrick;
 import dev.enjarai.trickster.spell.trick.inventory.*;
 import dev.enjarai.trickster.spell.trick.list.*;
 import dev.enjarai.trickster.spell.trick.math.*;
-import dev.enjarai.trickster.spell.trick.misc.ClearBarTrick;
-import dev.enjarai.trickster.spell.trick.misc.DelayExecutionTrick;
-import dev.enjarai.trickster.spell.trick.misc.ShowBarTrick;
-import dev.enjarai.trickster.spell.trick.misc.TypeFragmentTrick;
+import dev.enjarai.trickster.spell.trick.misc.*;
 import dev.enjarai.trickster.spell.trick.projectile.SummonDragonBreathTrick;
 import dev.enjarai.trickster.spell.trick.projectile.SummonFireballTrick;
 import dev.enjarai.trickster.spell.trick.projectile.SummonArrowTrick;
@@ -194,6 +191,7 @@ public class Tricks {
     // Misc
     public static final TypeFragmentTrick TYPE_FRAGMENT = register("type_fragment", new TypeFragmentTrick());
     public static final DelayExecutionTrick DELAY_EXECUTION = register("delay_execution", new DelayExecutionTrick());
+    public static final PinChunkTrick PIN_CHUNK = register("pin_chunk", new PinChunkTrick());
     public static final ShowBarTrick SHOW_BAR = register("show_bar", new ShowBarTrick());
     public static final ClearBarTrick CLEAR_BAR = register("clear_bar", new ClearBarTrick());
 

--- a/src/main/java/dev/enjarai/trickster/spell/trick/Tricks.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/Tricks.java
@@ -164,6 +164,7 @@ public class Tricks {
     public static final SwapBlockTrick SWAP_BLOCK = register("swap_block", new SwapBlockTrick());
     public static final ConjureFlowerTrick CONJURE_FLOWER = register("conjure_flower", new ConjureFlowerTrick());
     public static final ConjureWaterTrick CONJURE_WATER = register("conjure_water", new ConjureWaterTrick());
+    public static final DrainFluidTrick DRAIN_FLUID = register("drain_fluid", new DrainFluidTrick());
     public static final CheckBlockTrick CHECK_BLOCK = register("check_block", new CheckBlockTrick());
     public static final CanPlaceTrick CAN_PLACE_BLOCK = register("can_place_block", new CanPlaceTrick());
     public static final GetBlockHardnessTrick GET_BLOCK_HARDNESS = register("get_block_hardness", new GetBlockHardnessTrick());

--- a/src/main/java/dev/enjarai/trickster/spell/trick/block/DrainFluidTrick.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/block/DrainFluidTrick.java
@@ -1,0 +1,48 @@
+package dev.enjarai.trickster.spell.trick.block;
+
+import dev.enjarai.trickster.particle.ModParticles;
+import dev.enjarai.trickster.spell.Fragment;
+import dev.enjarai.trickster.spell.Pattern;
+import dev.enjarai.trickster.spell.SpellContext;
+import dev.enjarai.trickster.spell.fragment.FragmentType;
+import dev.enjarai.trickster.spell.fragment.VoidFragment;
+import dev.enjarai.trickster.spell.trick.Trick;
+import dev.enjarai.trickster.spell.trick.blunder.BlockUnoccupiedBlunder;
+import dev.enjarai.trickster.spell.trick.blunder.BlunderException;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.FluidDrainable;
+
+import java.util.List;
+
+public class DrainFluidTrick extends Trick {
+    public DrainFluidTrick() {
+        super(Pattern.of(3, 0, 4, 2, 5, 8, 1, 6, 3));
+    }
+
+    @Override
+    public Fragment activate(SpellContext ctx, List<Fragment> fragments) throws BlunderException {
+        var pos = expectInput(fragments, FragmentType.VECTOR, 0);
+        var blockPos = pos.toBlockPos();
+        var world = ctx.source().getWorld();
+        expectCanBuild(ctx, blockPos);
+
+        var state = world.getBlockState(blockPos);
+
+        if (state.getBlock() == Blocks.CAULDRON) {
+            world.setBlockState(blockPos, Blocks.CAULDRON.getDefaultState());
+        } else if (state.getBlock() instanceof FluidDrainable drainable) {
+            drainable.tryDrainFluid(ctx.source().getPlayer().orElse(null), world, blockPos, state);
+        } else {
+            throw new BlockUnoccupiedBlunder(this, pos);
+        }
+        ctx.useMana(this, 15);
+
+        var particlePos = blockPos.toCenterPos();
+        world.spawnParticles(
+                ModParticles.PROTECTED_BLOCK, particlePos.x, particlePos.y, particlePos.z,
+                1, 0, 0, 0, 0
+        );
+
+        return VoidFragment.INSTANCE;
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/spell/trick/blunder/NumberTooSmallBlunder.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/blunder/NumberTooSmallBlunder.java
@@ -1,0 +1,18 @@
+package dev.enjarai.trickster.spell.trick.blunder;
+
+import dev.enjarai.trickster.spell.trick.Trick;
+import net.minecraft.text.MutableText;
+
+public class NumberTooSmallBlunder extends TrickBlunderException {
+    private final int minimum;
+
+    public NumberTooSmallBlunder(Trick source, int minimum) {
+        super(source);
+        this.minimum = minimum;
+    }
+
+    @Override
+    public MutableText createMessage() {
+        return super.createMessage().append("Number too small, expected ").append("%d".formatted(minimum)).append(" or greater");
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/spell/trick/entity/PolymorphTrick.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/entity/PolymorphTrick.java
@@ -24,6 +24,9 @@ public class PolymorphTrick extends AbstractLivingEntityQueryTrick {
 
         var realTarget = getLivingEntity(ctx, fragments, 0);
 
+        if (realSource.getUuid().equals(realTarget.getUuid()))
+            return VoidFragment.INSTANCE;
+
         if (realTarget instanceof ServerPlayerEntity targetPlayer && realSource instanceof ServerPlayerEntity sourcePlayer) {
             ctx.useMana(this, 480);
 

--- a/src/main/java/dev/enjarai/trickster/spell/trick/entity/query/GetEntityManaTrick.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/entity/query/GetEntityManaTrick.java
@@ -24,7 +24,7 @@ public class GetEntityManaTrick extends AbstractLivingEntityQueryTrick {
         Fragment result = supposeType(arg, FragmentType.ENTITY).map(entity -> {
             var target = entity.getEntity(ctx).orElseThrow(() -> new UnknownEntityBlunder(this));
             if (!(target instanceof LivingEntity)) {
-                throw new EntityInvalidBlunder(this);
+                return new NumberFragment(0);
             }
 
             return new NumberFragment(ModEntityCumponents.MANA.get(target).get());
@@ -34,7 +34,7 @@ public class GetEntityManaTrick extends AbstractLivingEntityQueryTrick {
             result = supposeType(arg, FragmentType.VECTOR).map(vec -> {
                 var target = ctx.source().getWorld().getBlockEntity(vec.toBlockPos());
                 if (!(target instanceof SpellCircleBlockEntity)) {
-                    throw new BlockInvalidBlunder(this);
+                    return new NumberFragment(0);
                 }
 
                 return new NumberFragment(((SpellCircleBlockEntity) target).manaPool.get());

--- a/src/main/java/dev/enjarai/trickster/spell/trick/event/CreateSpellCircleTrick.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/event/CreateSpellCircleTrick.java
@@ -7,6 +7,7 @@ import dev.enjarai.trickster.spell.Fragment;
 import dev.enjarai.trickster.spell.Pattern;
 import dev.enjarai.trickster.spell.PatternGlyph;
 import dev.enjarai.trickster.spell.SpellContext;
+import dev.enjarai.trickster.spell.execution.executor.DefaultSpellExecutor;
 import dev.enjarai.trickster.spell.fragment.BooleanFragment;
 import dev.enjarai.trickster.spell.fragment.FragmentType;
 import dev.enjarai.trickster.spell.trick.Trick;
@@ -55,6 +56,9 @@ public class CreateSpellCircleTrick extends Trick {
             var entity = (SpellCircleBlockEntity) ctx.source().getWorld().getBlockEntity(blockPos);
 
             entity.event = event;
+            if (event.isMultiTick()) {
+                entity.executor = new DefaultSpellExecutor(spell, List.of());
+            }
             entity.spell = spell;
             entity.markDirty();
 

--- a/src/main/java/dev/enjarai/trickster/spell/trick/inventory/DropStackFromSlotTrick.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/inventory/DropStackFromSlotTrick.java
@@ -1,0 +1,37 @@
+package dev.enjarai.trickster.spell.trick.inventory;
+
+import dev.enjarai.trickster.spell.Fragment;
+import dev.enjarai.trickster.spell.Pattern;
+import dev.enjarai.trickster.spell.SpellContext;
+import dev.enjarai.trickster.spell.fragment.EntityFragment;
+import dev.enjarai.trickster.spell.fragment.FragmentType;
+import dev.enjarai.trickster.spell.fragment.NumberFragment;
+import dev.enjarai.trickster.spell.trick.Trick;
+import dev.enjarai.trickster.spell.trick.blunder.BlunderException;
+import dev.enjarai.trickster.spell.trick.blunder.NumberTooSmallBlunder;
+import net.minecraft.entity.ItemEntity;
+
+import java.util.List;
+
+public class DropStackFromSlotTrick extends Trick {
+    public DropStackFromSlotTrick() {
+        super(Pattern.of(1, 4, 7, 3, 4, 5, 7));
+    }
+
+    @Override
+    public Fragment activate(SpellContext ctx, List<Fragment> fragments) throws BlunderException {
+        var slot = expectInput(fragments, FragmentType.SLOT, 0);
+        var pos = expectInput(fragments, FragmentType.VECTOR, 1).toBlockPos();
+        var amount = supposeInput(fragments, FragmentType.NUMBER, 2).orElse(new NumberFragment(1)).number();
+
+        if (amount < 1)
+            throw new NumberTooSmallBlunder(this, 1);
+
+        var stack = slot.move(this, ctx, (int) Math.round(amount), pos);
+        var world = ctx.source().getWorld();
+        var entity = new ItemEntity(world, pos.getX(), pos.getY(), pos.getZ(), stack);
+
+        world.spawnEntity(entity);
+        return new EntityFragment(entity.getUuid(), entity.getName());
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/spell/trick/misc/PinChunkTrick.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/misc/PinChunkTrick.java
@@ -1,0 +1,30 @@
+package dev.enjarai.trickster.spell.trick.misc;
+
+import dev.enjarai.trickster.cca.ModWorldCumponents;
+import dev.enjarai.trickster.spell.Fragment;
+import dev.enjarai.trickster.spell.Pattern;
+import dev.enjarai.trickster.spell.SpellContext;
+import dev.enjarai.trickster.spell.fragment.BooleanFragment;
+import dev.enjarai.trickster.spell.fragment.FragmentType;
+import dev.enjarai.trickster.spell.trick.Trick;
+import dev.enjarai.trickster.spell.trick.blunder.BlunderException;
+import net.minecraft.util.math.ChunkPos;
+
+import java.util.List;
+
+public class PinChunkTrick extends Trick {
+    public PinChunkTrick() {
+        super(Pattern.of(6, 5, 0, 7, 2, 3, 8, 1, 6));
+    }
+
+    @Override
+    public Fragment activate(SpellContext ctx, List<Fragment> fragments) throws BlunderException {
+        var pos = expectInput(fragments, FragmentType.VECTOR, 0);
+        var chunkPos = new ChunkPos(pos.toBlockPos());
+
+        ctx.useMana(this, 32);
+        ModWorldCumponents.PINNED_CHUNKS.get(ctx.source().getWorld()).pinChunk(chunkPos);
+
+        return BooleanFragment.TRUE;
+    }
+}

--- a/src/main/java/dev/enjarai/trickster/spell/world/SpellCircleEvent.java
+++ b/src/main/java/dev/enjarai/trickster/spell/world/SpellCircleEvent.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 import static dev.enjarai.trickster.block.SpellCircleBlockEntity.LISTENER_RADIUS;
 
-public record SpellCircleEvent(Identifier id, Pattern pattern) {
+public record SpellCircleEvent(Identifier id, Pattern pattern, boolean isMultiTick) {
     private static final Map<Pattern, SpellCircleEvent> LOOKUP = new HashMap<>();
 
     public static final RegistryKey<Registry<SpellCircleEvent>> REGISTRY_KEY = RegistryKey.ofRegistry(Trickster.id("circle_event"));
@@ -44,12 +44,16 @@ public record SpellCircleEvent(Identifier id, Pattern pattern) {
     public static final SpellCircleEvent ENTITY_MOVE = register("entity_move", Pattern.of(3, 4, 5, 8, 4));
     public static final SpellCircleEvent USE_ITEM = register("use_item", Pattern.of(0, 4, 8, 5, 1, 0, 3, 7, 8));
 
-    public static final SpellCircleEvent TICK = register("tick", Pattern.of(0, 3, 6, 7, 8, 5, 2, 1, 0, 4, 5));
+    public static final SpellCircleEvent TICK = register("tick", Pattern.of(0, 3, 6, 7, 8, 5, 2, 1, 0, 4, 5), true);
     public static final SpellCircleEvent REDSTONE_UPDATE = register("redstone_update", Pattern.of(1, 5, 8, 7, 6, 3, 1));
 
-    private static SpellCircleEvent register(String path, Pattern pattern) {
+    private static SpellCircleEvent register(String path, Pattern pattern, boolean isMultiTick) {
         var id = Trickster.id(path);
-        return Registry.register(REGISTRY, id, new SpellCircleEvent(id, pattern));
+        return Registry.register(REGISTRY, id, new SpellCircleEvent(id, pattern, isMultiTick));
+    }
+
+    private static SpellCircleEvent register(String path, Pattern pattern) {
+        return register(path, pattern, false);
     }
 
     public static void register() {

--- a/src/main/resources/assets/trickster/lang/en_us.yml
+++ b/src/main/resources/assets/trickster/lang/en_us.yml
@@ -63,7 +63,9 @@ trickster:
 
     height_reflection: Stature Distortion
     sneaking_reflection: Alternative Distortion
-    raycast: Scout's Distortion
+    raycast: Archer's Distortion
+    raycast_side: Architect's Distortion
+    raycast_entity: Scout's Distortion
     get_entity_type: Motive Verification Distortion
     get_position: Locational Distortion
     get_facing: Directional Distortion
@@ -74,6 +76,9 @@ trickster:
     get_velocity: Movement Distortion
     leech_mana: Conduit's Ploy
     add_velocity: Impulse Ploy
+
+    polymorph: Polymorph Ploy
+    dispel_polymorph: Dispel Polymorph Ploy
 
     summon_arrow: Ballista's Ploy
     summon_fireball: Pyromancer's Ploy

--- a/src/main/resources/assets/trickster/lang/en_us.yml
+++ b/src/main/resources/assets/trickster/lang/en_us.yml
@@ -126,6 +126,7 @@ trickster:
     swap_block: Ploy of Exchange
     conjure_flower: Floral Ploy
     conjure_water: Aquatic Ploy
+    drain_fluid: Drought Ploy
     destabilize_block: Earthquake Ploy
     disguise_block: Shadow Ploy
     dispel_block_disguise: Revelation Ploy

--- a/src/main/resources/assets/trickster/lang/en_us.yml
+++ b/src/main/resources/assets/trickster/lang/en_us.yml
@@ -195,6 +195,8 @@ tag.item.trickster:
 
 death.attack:
   mana_overflux: "%1$s's magic show has met an untimely end."
+  mana_overflux.player: "%1$s's magic show has met an untimely end."
+  mana_overflux.entity: "%1$s's magic show has met an untimely end."
 
 key:
   categories:

--- a/src/main/resources/assets/trickster/lang/en_us.yml
+++ b/src/main/resources/assets/trickster/lang/en_us.yml
@@ -139,6 +139,7 @@ trickster:
 
     type_fragment: Argumentative Distortion
     delay_execution: Ploy of Suspension
+    pin_chunk: Ploy of Celestial Pin
     show_bar: Ploy of Clarity
     clear_bar: Ploy of Obfuscation
 

--- a/src/main/resources/assets/trickster/lang/en_us.yml
+++ b/src/main/resources/assets/trickster/lang/en_us.yml
@@ -195,8 +195,7 @@ tag.item.trickster:
 
 death.attack:
   mana_overflux: "%1$s's magic show has met an untimely end."
-  mana_overflux.player: "%1$s's magic show has met an untimely end."
-  mana_overflux.entity: "%1$s's magic show has met an untimely end."
+  mana_overflux.player: "%2$ brought an end to %1$s's magic show."
 
 key:
   categories:

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/block_events.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/block_events.md
@@ -1,6 +1,6 @@
 ```json
 {
-  "title": "Block Events",
+  "title": "General Events",
   "icon": "minecraft:smooth_stone",
   "category": "trickster:events"
 }
@@ -14,11 +14,10 @@ This entry lists available event patterns relating to blocks and block interacti
 
 {gray}(Event pattern){}
 
-number
-
 ---
 
-Triggers automatically every half second, receiving the amount of times this circle was triggered previously.
+Triggers once when created, but can continue indefinitely so long as no blunder is encountered. 
+Spell circle is deleted when the spell ends.
 
 ;;;;;
 

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/block_ploys.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/block_ploys.md
@@ -63,6 +63,16 @@ Conjures a small splash of water at the given position.
 
 ;;;;;
 
+<|glyph@trickster:templates|trick-id=trickster:drain_fluid,title=Drought Ploy|>
+
+vector ->
+
+<|cost-rule@trickster:templates|formula=15kG|>
+
+Drains any fluid at the given position.
+
+;;;;;
+
 <|glyph@trickster:templates|trick-id=trickster:destabilize_block,title=Earthquake Ploy|>
 
 vector ->

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/inventory.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/inventory.md
@@ -34,13 +34,19 @@ Returns the type of item in the caster's other hand.
 
 number, [vector] -> slot
 
-<|cost-rule@trickster:templates|formula=When used:
-  if external
-    32kG + distance * 0.8
-  else
-    0kG|>
+---
 
 Returns the item slot at the given index in either the inventory of the caster, or the block at the given position.
+
+;;;;;
+
+<|glyph@trickster:templates|trick-id=trickster:drop_stack_from_slot,title=Benevolent Distortion|>
+
+slot, vector, [number] -> entity
+
+---
+
+Drops items from the given slot at the given vector, and returns their entity. Optionally, the count of items can be specified.
 
 ;;;;;
 

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/misc.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/misc.md
@@ -30,6 +30,16 @@ Delays the execution of the current spell by the given number of ticks, or until
 
 ;;;;;
 
+<|glyph@trickster:templates|trick-id=trickster:pin_chunk,title=Ploy of Celestial Pin|>
+
+vector -> boolean
+
+<|cost-rule@trickster:templates|formula=32kG|>
+
+Fully loads the chunk containing the given position for exactly 4 seconds.
+
+;;;;;
+
 <|page-title@lavender:book_components|title=Note: Bars|>Spells can display arbitrary values on the caster's screen as bars.
 
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,7 +26,10 @@
 			"dev.enjarai.trickster.datagen.ModDataStuff"
 		],
 		"cardinal-components-chunk": [
-          	"dev.enjarai.trickster.cca.ModChunkCumponents"
+			"dev.enjarai.trickster.cca.ModChunkCumponents"
+		],
+		"cardinal-components-world": [
+			"dev.enjarai.trickster.cca.ModWorldCumponents"
 		],
 		"cardinal-components-entity": [
 			"dev.enjarai.trickster.cca.ModEntityCumponents"
@@ -40,7 +43,8 @@
 			"trickster:bars",
 			"trickster:ward",
 			"trickster:disguise",
-			"trickster:is_editing_scroll"
+			"trickster:is_editing_scroll",
+			"trickster:pinned_chunks"
 		]
 	},
 	"mixins": [

--- a/src/main/resources/trickster.mixins.json
+++ b/src/main/resources/trickster.mixins.json
@@ -7,6 +7,7 @@
     "AbstractBlockStateMixin",
     "LivingEntityMixin",
     "WorldChunkMixin",
+    "chunk_pinning.MinecraftServerMixin",
     "event.EntityMixin",
     "event.ItemStackMixin",
     "event.LivingEntityMixin",

--- a/src/main/resources/trickster.mixins.json
+++ b/src/main/resources/trickster.mixins.json
@@ -8,6 +8,8 @@
     "LivingEntityMixin",
     "WorldChunkMixin",
     "chunk_pinning.MinecraftServerMixin",
+    "chunk_pinning.ServerChunkLoadingManagerMixin",
+    "chunk_pinning.ServerWorldMixin",
     "event.EntityMixin",
     "event.ItemStackMixin",
     "event.LivingEntityMixin",


### PR DESCRIPTION
Tweaks single-use spell scrolls to not be consumed if they are done executing within a single tick and have not consumed any mana. 

Also includes a rewrite of `DefaultSpellExecutor#flattenNode` by @ArkoSammy12 that has flattened its logic (pun unintended), so that there is no risk of a `StackOverflowException`. 

Fixes #24. Fixes #25. 