### PR TITLE
Fix overcasting blundering even if the player is alive

### DIFF
--- a/src/main/java/dev/enjarai/trickster/cca/ManaComponent.java
+++ b/src/main/java/dev/enjarai/trickster/cca/ManaComponent.java
@@ -72,7 +72,7 @@ public class ManaComponent extends SimpleManaPool implements AutoSyncedComponent
 
         if (f < 0) {
             entity.damage(ModDamageTypes.of(entity.getWorld(), ModDamageTypes.MANA_OVERFLUX), ManaPool.healthFromMana(f * -1));
-            return entity.isAlive() && Boolean.FALSE.equals(entity.getAttached(ModAttachments.WHY_IS_THERE_NO_WAY_TO_DETECT_THIS));
+            return entity.isAlive() && (entity.getAttached(ModAttachments.WHY_IS_THERE_NO_WAY_TO_DETECT_THIS) instanceof Boolean b) && Boolean.FALSE.equals(b);
         }
 
         return true;

--- a/src/main/java/dev/enjarai/trickster/spell/mana/ManaLink.java
+++ b/src/main/java/dev/enjarai/trickster/spell/mana/ManaLink.java
@@ -63,7 +63,6 @@ public final class ManaLink {
         float result = availableMana;
 
         if (amount > availableMana) {
-
             if (!manaPool.decrease(availableMana))
                 availableMana -= oldMana;
             else


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/enjarai/trickster/commit/e46799cee813127cae55aeed051753c0aca67c7c that causes the engine to believe an entity is out of mana as soon as it draws blood. 