### PR TITLE
Fix sources linked by executor children being ignored once the child finishes

### DIFF
--- a/src/main/java/dev/enjarai/trickster/spell/execution/ExecutionState.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/ExecutionState.java
@@ -71,6 +71,7 @@ public class ExecutionState {
 
         var state = new ExecutionState(recursions + 1, arguments, poolOverride, stacktrace);
         state.stacktrace.push(-2);
+        state.syncLinksFrom(this);
         return state;
     }
 
@@ -155,6 +156,11 @@ public class ExecutionState {
 
     public int getInitialStacktraceSize() {
         return initialStacktraceSize;
+    }
+
+    public void syncLinksFrom(ExecutionState state) {
+        manaLinks.clear();
+        manaLinks.addAll(state.manaLinks);
     }
 
     public void addManaLink(Trick trickSource, LivingEntity target, float ownerHealth, float limit) throws BlunderException {

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/DefaultSpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/DefaultSpellExecutor.java
@@ -109,8 +109,7 @@ public class DefaultSpellExecutor implements SpellExecutor {
     protected Optional<Fragment> run(SpellContext ctx, int executions) throws BlunderException {
         lastRunExecutions = 0;
 
-        if (child.isPresent())
-        {
+        if (child.isPresent()) {
             var result = runChild(ctx, executions);
 
             if (result.isEmpty())
@@ -214,6 +213,7 @@ public class DefaultSpellExecutor implements SpellExecutor {
 
         if (result.isPresent()) {
             inputs.push(result.get());
+            state.syncLinksFrom(child.get().getCurrentState());
             child = Optional.empty();
         }
 

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/IteratorSpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/IteratorSpellExecutor.java
@@ -55,8 +55,7 @@ public class IteratorSpellExecutor extends DefaultSpellExecutor {
     protected Optional<Fragment> run(SpellContext ctx, int executions) throws BlunderException {
         lastRunExecutions = 0;
 
-        if (child.isPresent())
-        {
+        if (child.isPresent()) {
             var result = runChild(ctx, executions);
 
             if (result.isEmpty())

--- a/src/main/java/dev/enjarai/trickster/spell/execution/executor/TryCatchSpellExecutor.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/executor/TryCatchSpellExecutor.java
@@ -38,9 +38,9 @@ public class TryCatchSpellExecutor extends DefaultSpellExecutor {
 
     public TryCatchSpellExecutor(SpellContext ctx, SpellPart trySpell, SpellPart catchSpell, List<Fragment> arguments) {
         super(new SpellPart(), List.of());
-        this.state = ctx.executionState().recurseOrThrow(List.of());
-        this.trySpell = new DefaultSpellExecutor(trySpell, this.state.recurseOrThrow(arguments));
-        this.catchSpell = new DefaultSpellExecutor(catchSpell, this.state.recurseOrThrow(arguments));
+        this.trySpell = new DefaultSpellExecutor(trySpell, ctx.executionState().recurseOrThrow(arguments));
+        this.catchSpell = new DefaultSpellExecutor(catchSpell, ctx.executionState().recurseOrThrow(arguments));
+        this.state = this.trySpell.getCurrentState();
     }
 
     @Override
@@ -59,6 +59,8 @@ public class TryCatchSpellExecutor extends DefaultSpellExecutor {
             return trySpell.run(ctx.source());
         } catch (BlunderException blunder) {
             catching = true;
+            state = catchSpell.getCurrentState();
+            state.syncLinksFrom(trySpell.getCurrentState());
             return catchSpell.run(ctx.source());
         }
     }

--- a/src/main/java/dev/enjarai/trickster/spell/mana/ManaLink.java
+++ b/src/main/java/dev/enjarai/trickster/spell/mana/ManaLink.java
@@ -59,17 +59,14 @@ public final class ManaLink {
             throw new NotEnoughManaBlunder(trickSource, amount);
 
         var manaPool = this.manaPool.apply(trickSource, world);
-        float oldMana = manaPool.get();
         float result = availableMana;
 
         if (amount > availableMana) {
-            if (!manaPool.decrease(availableMana))
-                availableMana -= oldMana;
-            else
-                availableMana = 0;
+            manaPool.decrease(availableMana);
+            availableMana = 0;
         } else {
             if (!manaPool.decrease(amount))
-                availableMana -= oldMana;
+                availableMana = 0;
             else
                 availableMana -= amount;
         }


### PR DESCRIPTION
Spell executors now sync their children's mana links to ensure that all links persist across the spell. 