### PR TITLE
Fix "infinite" caster mana when mana links have no available mana

### DIFF
--- a/src/main/java/dev/enjarai/trickster/block/cauldron/EraseSpellCauldronBehavior.java
+++ b/src/main/java/dev/enjarai/trickster/block/cauldron/EraseSpellCauldronBehavior.java
@@ -1,7 +1,6 @@
 package dev.enjarai.trickster.block.cauldron;
 
 import dev.enjarai.trickster.item.ModItems;
-import dev.enjarai.trickster.item.component.ModComponents;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.cauldron.CauldronBehavior;
 import net.minecraft.entity.player.PlayerEntity;
@@ -14,8 +13,6 @@ import net.minecraft.world.World;
 public class EraseSpellCauldronBehavior implements CauldronBehavior {
     @Override
     public ItemActionResult interact(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, ItemStack stack) {
-        stack.remove(ModComponents.WRITTEN_SCROLL_META);
-        stack.remove(ModComponents.SPELL);
         player.setStackInHand(hand, stack.withItem(ModItems.SCROLL_AND_QUILL));
         return ItemActionResult.SUCCESS;
     }

--- a/src/main/java/dev/enjarai/trickster/net/SignScrollPacket.java
+++ b/src/main/java/dev/enjarai/trickster/net/SignScrollPacket.java
@@ -18,10 +18,9 @@ public record SignScrollPacket(Hand hand, String name) {
                 return;
             }
 
-            var spell = component.spell();
             var newStack = ModItems.WRITTEN_SCROLL.getDefaultStack();
 
-            newStack.set(ModComponents.SPELL, new SpellComponent(spell, true));
+            newStack.set(ModComponents.SPELL, new SpellComponent(component.spell(), true, component.closed()));
             newStack.set(ModComponents.WRITTEN_SCROLL_META, new WrittenScrollMetaComponent(
                     name(), player.getName().getString(), 0
             ));

--- a/src/main/java/dev/enjarai/trickster/spell/execution/ExecutionState.java
+++ b/src/main/java/dev/enjarai/trickster/spell/execution/ExecutionState.java
@@ -182,18 +182,20 @@ public class ExecutionState {
     }
 
     public void useMana(Trick trickSource, SpellContext ctx, ManaPool pool, float amount) throws NotEnoughManaBlunder {
+        var links = manaLinks.stream().filter(link -> link.getAvailable() > 0).toList();
         hasUsedMana = true;
 
-        if (!manaLinks.isEmpty()) {
+        if (!links.isEmpty()) {
             float totalAvailable = 0;
             float leftOver = 0;
 
-            for (var link : manaLinks) {
+            for (var link : links) {
                 totalAvailable += link.getAvailable();
             }
 
-            for (var link : manaLinks) {
+            for (var link : links) {
                 float available = link.getAvailable();
+
                 float ratio = available / totalAvailable;
                 float ratioD = amount * ratio;
                 float used = link.useMana(trickSource, ctx.source().getWorld(), pool, ratioD);

--- a/src/main/java/dev/enjarai/trickster/spell/mana/ManaLink.java
+++ b/src/main/java/dev/enjarai/trickster/spell/mana/ManaLink.java
@@ -3,6 +3,7 @@ package dev.enjarai.trickster.spell.mana;
 import dev.enjarai.trickster.EndecTomfoolery;
 import dev.enjarai.trickster.cca.ManaComponent;
 import dev.enjarai.trickster.cca.ModEntityCumponents;
+import dev.enjarai.trickster.entity.ModEntities;
 import dev.enjarai.trickster.spell.fragment.EntityFragment;
 import dev.enjarai.trickster.spell.trick.Trick;
 import dev.enjarai.trickster.spell.trick.blunder.BlunderException;
@@ -31,7 +32,6 @@ public final class ManaLink {
             ManaLink::new
     );
 
-                                // TODO: FIX ME AURI
     private ManaLink(UUID targetUuid, float taxRatio, float availableMana) {
         this.source = (trickSource, world) -> {
             var entity = world.getEntity(targetUuid);
@@ -48,13 +48,29 @@ public final class ManaLink {
         this.availableMana = availableMana;
     }
 
+    /**
+     * A link to a living entity's mana pool.
+     * @param source the living entity being linked. Its health is used as the denominator of the tax ratio.
+     * @param ownerHealth the numerator of the tax ratio.
+     * @param availableMana the total amount of mana this link may drain.
+     */
     public ManaLink(LivingEntity source, float ownerHealth, float availableMana) {
-        this(source.getUuid(), ownerHealth / source.getHealth(), availableMana);
+        this(source.getUuid(), ownerHealth / source.getHealth(), source.getType().isIn(ModEntities.MANA_DEVOID) ? 0 : availableMana);
     }
 
-    public float useMana(Trick trickSource, ServerWorld world, ManaPool owner, float amount) throws BlunderException {
-        if (!owner.decrease(amount / taxRatio))
-            throw new NotEnoughManaBlunder(trickSource, amount);
+    /**
+     * Drains the source's mana, applying tax to the owner of the link.
+     * @param trickSource the trick this call originates from.
+     * @param owner the mana pool that this link belongs to.
+     * @param amount the amount of mana to drain from the linked source.
+     * @return the amount of mana drained from the linked source.
+     * @throws NotEnoughManaBlunder if the owner does not have sufficient mana to drain the linked source.
+     */
+    public float useMana(Trick trickSource, ServerWorld world, ManaPool owner, float amount) throws NotEnoughManaBlunder {
+        var taxAmount = amount / taxRatio;
+
+        if (!owner.decrease(taxAmount))
+            throw new NotEnoughManaBlunder(trickSource, taxAmount);
 
         var manaPool = this.manaPool.apply(trickSource, world);
         float result = availableMana;
@@ -63,10 +79,9 @@ public final class ManaLink {
             manaPool.decrease(availableMana);
             availableMana = 0;
         } else {
-            if (!manaPool.decrease(amount))
-                availableMana = 0;
-            else
+            if (manaPool.decrease(amount))
                 availableMana -= amount;
+            else availableMana = 0;
         }
 
         return result - availableMana;

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/raycast.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/raycast.md
@@ -7,13 +7,14 @@
 ```
 
 Raycasting tricks take either an entity or a position and a direction, and will return what the entity is looking at, 
-or the vectors are pointing to.
+or what the vectors are pointing to.
 
 ;;;;;
 
 <|glyph@trickster:templates|trick-id=trickster:raycast,title=Archer's Distortion|>
 
 entity -> vector |
+
 vector, vector -> vector
 
 ---
@@ -25,6 +26,7 @@ Returns the block that is hit.
 <|glyph@trickster:templates|trick-id=trickster:raycast_side,title=Architect's Distortion|>
 
 entity -> vector |
+
 vector, vector -> vector
 
 ---
@@ -36,6 +38,7 @@ Returns a vector representing the side of the block that is hit.
 <|glyph@trickster:templates|trick-id=trickster:raycast_entity,title=Scout's Distortion|>
 
 entity -> entity |
+
 vector, vector -> entity
 
 ---


### PR DESCRIPTION
Makes `useMana` ignore links that have been run dry. 