### PR TITLE
Fix wards using == and != instead of .equals

### DIFF
--- a/src/main/java/dev/enjarai/trickster/compat/pehkui/SetScaleTrick.java
+++ b/src/main/java/dev/enjarai/trickster/compat/pehkui/SetScaleTrick.java
@@ -19,11 +19,12 @@ public class SetScaleTrick extends Trick {
 
     @Override
     public Fragment activate(SpellContext ctx, List<Fragment> fragments) throws BlunderException {
-        var target = expectInput(fragments, FragmentType.ENTITY, 0);
-        var scale = expectInput(fragments, FragmentType.NUMBER, 1);
+        var target = expectInput(fragments, FragmentType.ENTITY, 0).getEntity(ctx).orElseThrow(() -> new UnknownEntityBlunder(this));
 
-        var scaleData = ScaleTypes.BASE.getScaleData(target.getEntity(ctx)
-                        .orElseThrow(() -> new UnknownEntityBlunder(this)));
+        fragments = tryWard(ctx, target, fragments);
+
+        var scale = expectInput(fragments, FragmentType.NUMBER, 1);
+        var scaleData = ScaleTypes.BASE.getScaleData(target);
 
         var difference = Math.abs(scale.number() - scaleData.getScale());
         ctx.useMana(this, (float) (difference * difference * 10));

--- a/src/main/java/dev/enjarai/trickster/item/TrickyAccessoryItem.java
+++ b/src/main/java/dev/enjarai/trickster/item/TrickyAccessoryItem.java
@@ -67,14 +67,14 @@ public class TrickyAccessoryItem extends AccessoryItem {
                         isModified = true;
                     }
 
-                    if (newInput.type() != inputType)
+                    if (!newInput.type().equals(inputType))
                         throw new WardReturnBlunder();
 
-                    if (inputType == FragmentType.ENTITY) {
+                    if (inputType.equals(FragmentType.ENTITY)) {
                         var entity = (EntityFragment)input;
                         var newEntity = (EntityFragment)newInput;
 
-                        if (entity.uuid() == player.getUuid() && newEntity.uuid() != entity.uuid())
+                        if (entity.uuid().equals(player.getUuid()) && !newEntity.uuid().equals(entity.uuid()))
                             throw new WardModifiedSelfBlunder();
                     }
 


### PR DESCRIPTION
Resolves an issue that caused warding for impulse to fail wrongfully. 