### PR TITLE
Fix crashes on NeoForge (via Sinytra Connector)

### DIFF
--- a/src/main/java/dev/enjarai/trickster/item/ModItems.java
+++ b/src/main/java/dev/enjarai/trickster/item/ModItems.java
@@ -56,7 +56,6 @@ public class ModItems {
                             .nutrition(0)
                             .saturationModifier(0)
                             .alwaysEdible()
-                            .snack() // 0.8F instead of 1.0F
                             .usingConvertsTo(Items.GLASS_BOTTLE)
                             .statusEffect(new StatusEffectInstance(StatusEffects.NAUSEA, 60 * 20), 1)
                             .statusEffect(new StatusEffectInstance(StatusEffects.POISON, 60 * 20), 1)

--- a/src/main/java/dev/enjarai/trickster/item/ModItems.java
+++ b/src/main/java/dev/enjarai/trickster/item/ModItems.java
@@ -22,7 +22,6 @@ import net.minecraft.util.DyeColor;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 public class ModItems {
     public static final LavenderBookItem TOME_OF_TOMFOOLERY = LavenderBookItem.registerForBook(
@@ -53,15 +52,17 @@ public class ModItems {
             new Item(new Item.Settings().maxCount(1)));
     public static final SpellInkItem SPELL_INK = register("spell_ink",
             new SpellInkItem(new Item.Settings().recipeRemainder(Items.GLASS_BOTTLE)
-                    .food(new FoodComponent(0,
-                            0,
-                            true,
-                            1,
-                            Optional.of(Items.GLASS_BOTTLE.getDefaultStack()),
-                            List.of(new FoodComponent.StatusEffectEntry(new StatusEffectInstance(StatusEffects.NAUSEA, 60 * 20), 1),
-                                    new FoodComponent.StatusEffectEntry(new StatusEffectInstance(StatusEffects.POISON, 60 * 20), 1),
-                                    new FoodComponent.StatusEffectEntry(new StatusEffectInstance(StatusEffects.GLOWING, 60 * 20), 1),
-                                    new FoodComponent.StatusEffectEntry(new StatusEffectInstance(StatusEffects.BLINDNESS, 60 * 20), 1))))));
+                    .food(new FoodComponent.Builder()
+                            .nutrition(0)
+                            .saturationModifier(0)
+                            .alwaysEdible()
+                            .snack() // 0.8F instead of 1.0F
+                            .usingConvertsTo(Items.GLASS_BOTTLE)
+                            .statusEffect(new StatusEffectInstance(StatusEffects.NAUSEA, 60 * 20), 1)
+                            .statusEffect(new StatusEffectInstance(StatusEffects.POISON, 60 * 20), 1)
+                            .statusEffect(new StatusEffectInstance(StatusEffects.GLOWING, 60 * 20), 1)
+                            .statusEffect(new StatusEffectInstance(StatusEffects.BLINDNESS, 60 * 20), 1)
+                            .build())));
     public static final BlockItem SPELL_RESONATOR_BLOCK_ITEM = register("spell_resonator", new BlockItem(ModBlocks.SPELL_RESONATOR, new Item.Settings()));
     public static final BlockItem SCROLL_SHELF_BLOCK_ITEM = register("scroll_shelf", new BlockItem(ModBlocks.SCROLL_SHELF, new Item.Settings()));
 

--- a/src/main/java/dev/enjarai/trickster/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/enjarai/trickster/mixin/LivingEntityMixin.java
@@ -131,7 +131,7 @@ public abstract class LivingEntityMixin extends Entity implements DirectlyDamage
             inShadowBlock = inShadowBlock(getWorld(), BlockPos.ofFloored(this.getEyePos()));
         }
 
-        setAttached(ModAttachments.WHY_IS_THERE_NO_WAY_TO_DETECT_THIS, null);
+        removeAttached(ModAttachments.WHY_IS_THERE_NO_WAY_TO_DETECT_THIS);
 
         if (!ModEntityComponents.GRACE.get(this).isInGrace("scale")) {
             // Handle slow scaling reset


### PR DESCRIPTION
This PR fixes a few things that made the mod crash on NeoForge (when running via [Sinytra Connector](https://modrinth.com/mod/connector)).

Note that the `eatSeconds` of `ModItems.SPELL_INK` was reduced to `0.8F` from `1.0F` (via `.snack()`), as `FoodComponent.Builder` does not provide a method to change that value directly - it can only be either `1.6F` or `0.8F`. This can technically be worked around via mixin.

(the `remap = false` just silences a compiler warning)