### PR TITLE
Fix top hat wrapping in preview when there is only one possible slot

### DIFF
--- a/src/client/java/dev/enjarai/trickster/mixin/client/InGameHudMixin.java
+++ b/src/client/java/dev/enjarai/trickster/mixin/client/InGameHudMixin.java
@@ -48,17 +48,15 @@ public class InGameHudMixin {
                 var offset = i - 1;
                 var scrollStack = TrickHatItem.getScrollRelative(hatStack, offset);
 
-                if (!scrollStack.equals(TrickHatItem.getScrollRelative(hatStack, 0))) {
-                    matrices.push();
-                    matrices.translate(0, 0, -Math.abs(offset));
+                matrices.push();
+                matrices.translate(0, 0, -Math.abs(offset));
 
-                    var brightness = offset == 0 ? 1f : 0.6f;
-                    RenderSystem.setShaderColor(brightness, brightness, brightness, brightness);
+                var brightness = offset == 0 ? 1f : 0.6f;
+                RenderSystem.setShaderColor(brightness, brightness, brightness, brightness);
 
-                    context.drawItem(scrollStack, x + offset * 8, y);
+                context.drawItem(scrollStack, x + offset * 8, y);
 
-                    matrices.pop();
-                }
+                matrices.pop();
             }
 
             RenderSystem.setShaderColor(1, 1, 1, 1);

--- a/src/client/java/dev/enjarai/trickster/mixin/client/InGameHudMixin.java
+++ b/src/client/java/dev/enjarai/trickster/mixin/client/InGameHudMixin.java
@@ -12,7 +12,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.Arm;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -21,28 +20,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(InGameHud.class)
 public class InGameHudMixin {
-    @Inject(
-            method = "renderVignetteOverlay",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIFFIIII)V"
-            )
-    )
+    @Inject(method = "renderVignetteOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIFFIIII)V"))
     private void changeColorWhenFrozen(DrawContext context, Entity entity, CallbackInfo ci) {
-        if (entity instanceof LivingEntity livingEntity &&
-                livingEntity.getAttributes().hasModifierForAttribute(EntityAttributes.GENERIC_MOVEMENT_SPEED, Trickster.NEGATE_ATTRIBUTE.id())) {
+        if (entity instanceof LivingEntity livingEntity
+                && livingEntity.getAttributes().hasModifierForAttribute(EntityAttributes.GENERIC_MOVEMENT_SPEED,
+                        Trickster.NEGATE_ATTRIBUTE.id())) {
             context.setShaderColor(0.4f, 0.4f, 0f, 1f);
         }
     }
 
-    @Inject(
-            method = "renderHotbar",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/option/SimpleOption;getValue()Ljava/lang/Object;"
-            )
-    )
-    private void renderHatHud(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci, @Local PlayerEntity player) {
+    @Inject(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/SimpleOption;getValue()Ljava/lang/Object;"))
+    private void renderHatHud(DrawContext context,
+            RenderTickCounter tickCounter,
+            CallbackInfo ci,
+            @Local PlayerEntity player) {
         var hatStack = player.getOffHandStack();
         if (hatStack.isIn(ModItems.HOLDABLE_HAT)) {
             var matrices = context.getMatrices();
@@ -55,16 +46,19 @@ public class InGameHudMixin {
 
             for (int i = 0; i < 3; i++) {
                 var offset = i - 1;
-                matrices.push();
-                matrices.translate(0, 0, -Math.abs(offset));
-
                 var scrollStack = TrickHatItem.getScrollRelative(hatStack, offset);
-                var brightness = offset == 0 ? 1f : 0.6f;
-                RenderSystem.setShaderColor(brightness, brightness, brightness, brightness);
 
-                context.drawItem(scrollStack, x + offset * 8, y);
+                if (!scrollStack.equals(TrickHatItem.getScrollRelative(hatStack, 0))) {
+                    matrices.push();
+                    matrices.translate(0, 0, -Math.abs(offset));
 
-                matrices.pop();
+                    var brightness = offset == 0 ? 1f : 0.6f;
+                    RenderSystem.setShaderColor(brightness, brightness, brightness, brightness);
+
+                    context.drawItem(scrollStack, x + offset * 8, y);
+
+                    matrices.pop();
+                }
             }
 
             RenderSystem.setShaderColor(1, 1, 1, 1);

--- a/src/main/java/dev/enjarai/trickster/item/TrickHatItem.java
+++ b/src/main/java/dev/enjarai/trickster/item/TrickHatItem.java
@@ -3,7 +3,6 @@ package dev.enjarai.trickster.item;
 import dev.enjarai.trickster.item.component.EntityStorageComponent;
 import dev.enjarai.trickster.item.component.ModComponents;
 import dev.enjarai.trickster.item.component.SelectedSlotComponent;
-import dev.enjarai.trickster.screen.ScrollAndQuillScreenHandler;
 import dev.enjarai.trickster.screen.ScrollContainerScreenHandler;
 import io.wispforest.accessories.api.AccessoryItem;
 import io.wispforest.accessories.api.slot.SlotReference;
@@ -13,7 +12,6 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.Equipment;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.NamedScreenHandlerFactory;
 import net.minecraft.screen.ScreenHandler;
@@ -70,23 +68,32 @@ public class TrickHatItem extends AccessoryItem implements Equipment {
     public static ItemStack getScrollRelative(ItemStack hatStack, int offset) {
         var slot = hatStack.get(ModComponents.SELECTED_SLOT);
         var container = hatStack.get(DataComponentTypes.CONTAINER);
+
         if (slot != null && container != null) {
-            var selected = slot.slot() + offset;
+            var selectedSlot = slot.slot() + offset;
             var maxSlot = (int) Math.min(slot.maxSlot(), container.stream().count());
 
-            if (maxSlot > 0) {
-                while (selected < 0) {
-                    selected += maxSlot;
-                }
-                while (selected >= maxSlot) {
-                    selected -= maxSlot;
-                }
-            } else {
-                selected = 0;
+            if (maxSlot <= 1 && offset != 0) {
+                return ItemStack.EMPTY;
             }
 
-            return container.stream().skip(selected).findFirst().orElse(ItemStack.EMPTY);
+            if (maxSlot > 0) {
+                while (selectedSlot < 0) {
+                    selectedSlot += maxSlot;
+                }
+                while (selectedSlot >= maxSlot) {
+                    selectedSlot -= maxSlot;
+                }
+            } else {
+                selectedSlot = 0;
+            }
+
+            return container.stream()
+                    .skip(selectedSlot)
+                    .findFirst()
+                    .orElse(ItemStack.EMPTY);
         }
+
         return ItemStack.EMPTY;
     }
 


### PR DESCRIPTION
Stops the top hat preview from wrapping when only one slot can be selected. It now looks like this when there is only one scroll in the first slot:
![image](https://github.com/user-attachments/assets/89d01fb5-f466-4bb9-8f02-5ab647646b32)
The wrapping returns even if there is but one other scroll in the top hat:
![image](https://github.com/user-attachments/assets/3e275159-1d60-4aee-98ee-04d53bad63ba)
Or if the only scroll is in a slot other than the first:
![image](https://github.com/user-attachments/assets/c8fb1efa-b3f6-4bec-a045-2429271779bd)

I'd like to know what you think, @enjarai, if there's maybe a better way to do this.