### PR TITLE
Improve glyph drawing

### DIFF
--- a/src/client/java/dev/enjarai/trickster/render/SpellCircleRenderer.java
+++ b/src/client/java/dev/enjarai/trickster/render/SpellCircleRenderer.java
@@ -1,6 +1,5 @@
 package dev.enjarai.trickster.render;
 
-import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import dev.enjarai.trickster.Trickster;
 import dev.enjarai.trickster.render.fragment.FragmentRenderer;
@@ -15,7 +14,6 @@ import net.minecraft.client.util.BufferAllocator;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
-import net.minecraft.util.math.RotationAxis;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.random.LocalRandom;
 import net.minecraft.util.math.random.Random;
@@ -23,8 +21,6 @@ import org.joml.Matrix4f;
 import org.joml.Vector2f;
 
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -36,7 +32,7 @@ public class SpellCircleRenderer {
     public static final Identifier CIRCLE_TEXTURE_HALF = Trickster.id("textures/gui/circle_24.png");
     public static final float PATTERN_TO_PART_RATIO = 2.5f;
     public static final int PART_PIXEL_RADIUS = 24;
-    public static final int CLICK_HITBOX_SIZE = 6;
+    public static final int CLICK_HITBOX_SIZE = 5;
 
     public static final RenderLayer CIRCLE_TEXTURE_LAYER = RenderLayer.getEntityTranslucent(CIRCLE_TEXTURE);
     public static final RenderLayer GLYPH_LAYER = RenderLayer.of(

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -26,10 +26,10 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     public static final double PRECISION_OFFSET = Math.pow(2, 50);
 
     static final Byte[] RING_ORDER = {
-        (byte) 0, (byte) 1, (byte) 2, (byte) 5, (byte) 8, (byte) 7, (byte) 6, (byte) 3
+            (byte) 0, (byte) 1, (byte) 2, (byte) 5, (byte) 8, (byte) 7, (byte) 6, (byte) 3
     };
     static final Byte[] RING_INDICES = {
-        (byte) 0, (byte) 1, (byte) 2, (byte) 7, (byte) 0, (byte) 3, (byte) 6, (byte) 5, (byte) 4
+            (byte) 0, (byte) 1, (byte) 2, (byte) 7, (byte) 0, (byte) 3, (byte) 6, (byte) 5, (byte) 4
     };
 
     private SpellPart rootSpellPart;
@@ -374,13 +374,12 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
             return false;
         } else {
             var i = RING_INDICES[a];
-            return
-                b == RING_ORDER[(i + 1) % 8] ||
-                b == RING_ORDER[i == 0 ? 7 : (i - 1) % 8];
+            return b == RING_ORDER[(i + 1) % 8] ||
+                    b == RING_ORDER[i == 0 ? 7 : (i - 1) % 8];
         }
     }
 
-    private boolean hasEdge(byte a, byte b) {
+    private boolean hasLine(byte a, byte b) {
         for (int i = 0; i < drawingPattern.size(); i++) {
             if (i < drawingPattern.size() - 1) {
                 var prev = drawingPattern.get(i);
@@ -404,16 +403,17 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                 moves.put(i, move);
             }
         } else {
-            var last = drawingPattern.get(drawingPattern.size() - 1);
+            var last = drawingPattern.getLast();
             for (byte i = 0; i < 9; i++) {
                 if (i == last) {
                     continue;
                 }
-                if (!hasEdge(i, last)) {
+
+                if (!hasLine(i, last)) {
                     var move = new ArrayList<Byte>(drawingPattern);
                     // resolve the middle dot if we are going across
                     if (i == 8 - last) {
-                        if (hasEdge(i, (byte) 4) || hasEdge(last, (byte) 4)) {
+                        if (hasLine(i, (byte) 4) || hasLine(last, (byte) 4)) {
                             // we are already connected to the middle dot
                             // going across is impossible
                             continue;
@@ -425,7 +425,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                     moves.put(i, move);
                 } else if (drawingPattern.size() >= 2 && drawingPattern.get(drawingPattern.size() - 2) == i) {
                     var move = new ArrayList<Byte>(drawingPattern);
-                    move.remove(drawingPattern.size() - 1);
+                    move.removeLast();
                     moves.put(i, move);
                 }
             }

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Vector2d;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Stack;
@@ -361,6 +362,59 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         super.mouseMoved(mouseX, mouseY);
     }
 
+    private boolean hasEdge(byte a, byte b) {
+        for (int i = 0; i < drawingPattern.size(); i++) {
+            if (i < drawingPattern.size() - 1) {
+                var prev = drawingPattern.get(i);
+                var next = drawingPattern.get(i + 1);
+                if ((prev == a && next == b) || (prev == b && next == a)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // generates all possible moves from the current drawingPattern
+    // assigns the target dot with the resulting next drawingPattern
+    private HashMap<Byte, List<Byte>> possibleMoves() {
+        var moves = new HashMap<Byte, List<Byte>>();
+        if (drawingPattern.isEmpty()) {
+            for (byte i = 0; i < 9; i++) {
+                var move = new ArrayList<Byte>();
+                move.add(i);
+                moves.put(i, move);
+            }
+        } else {
+            var last = drawingPattern.get(drawingPattern.size() - 1);
+            for (byte i = 0; i < 9; i++) {
+                if (i == last) {
+                    continue;
+                }
+                if (!hasEdge(i, last)) {
+                    var move = new ArrayList<Byte>(drawingPattern);
+                    // resolve the middle dot if we are going across
+                    if (i == 8 - last) {
+                        if (hasEdge(i, (byte) 4)) {
+                            // we are already connected to the middle dot
+                            // going across is impossible
+                            continue;
+                        } else {
+                            move.add((byte) 4);
+                        }
+                    }
+                    move.add(i);
+                    moves.put(i, move);
+                } else if (drawingPattern.size() >= 2 && drawingPattern.get(drawingPattern.size() - 2) == i) {
+                    var move = new ArrayList<Byte>(drawingPattern);
+                    move.remove(drawingPattern.size() - 1);
+                    moves.put(i, move);
+                }
+            }
+        }
+        return moves;
+    }
+
     @SuppressWarnings("resource")
     protected boolean selectPattern(SpellPart part, float x, float y, float size, double mouseX, double mouseY) {
         if (drawingPart != null && drawingPart != part) {
@@ -371,7 +425,15 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         var patternSize = size / PATTERN_TO_PART_RATIO;
         var pixelSize = patternSize / PART_PIXEL_RADIUS;
 
-        for (int i = 0; i < 9; i++) {
+        if (drawingPattern == null){
+            drawingPattern = new ArrayList<>();
+        }
+
+        var moves = possibleMoves();
+
+        for (byte i = 0; i < 9; i++) {
+            var _patternSize = patternSize;
+            
             var pos = getPatternDotPosition(x, y, i, patternSize);
 
             if (isInsideHitbox(pos, pixelSize, mouseX, mouseY)) {
@@ -379,36 +441,19 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                     drawingPart = part;
                     oldGlyph = part.glyph;
                     part.glyph = new PatternGlyph(List.of());
-                    drawingPattern = new ArrayList<>();
                 }
-
-                if (drawingPattern.size() >= 2 && drawingPattern.get(drawingPattern.size() - 2) == (byte) i) {
-                    drawingPattern.removeLast();
-                    MinecraftClient.getInstance().player.playSoundToPlayer(
-                            ModSounds.DRAW, SoundCategory.MASTER,
-                            1f, ModSounds.randomPitch(0.6f, 0.2f)
-                    );
-                } else if (
-                    drawingPattern.isEmpty() ||
-                            (drawingPattern.getLast() != (byte) i && !hasOverlappingLines(drawingPattern, drawingPattern.getLast(), (byte) i))
-                ) {
-                    drawingPattern.add((byte) i);
-
-                    //add middle point to path if connecting opposite corners
-                    if (drawingPattern.size() > 1 && drawingPattern.get(drawingPattern.size() - 2) == (byte) (8 - i))
-                        drawingPattern.add(drawingPattern.size() - 1, (byte) 4);
-
+                if (moves.get(i) != null) {
+                    boolean removing = drawingPattern.size() > moves.get(i).size();
+                    drawingPattern = moves.get(i);
                     // TODO click sound?
                     MinecraftClient.getInstance().player.playSoundToPlayer(
                             ModSounds.DRAW, SoundCategory.MASTER,
-                            1f, ModSounds.randomPitch(1f, 0.2f)
+                            1f, ModSounds.randomPitch(removing ? 0.6f : 1.0f, 0.2f)
                     );
                 }
-
                 return true;
             }
         }
-
         return false;
     }
 
@@ -486,20 +531,6 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
 
     public boolean isDrawing() {
         return drawingPart != null;
-    }
-
-    protected static boolean hasOverlappingLines(List<Byte> pattern, byte p1, byte p2) {
-        Byte first = null;
-
-        for (Byte second : pattern) {
-            if (first != null && (first == p1 && second == p2 || first == p2 && second == p1)) {
-                return true;
-            }
-
-            first = second;
-        }
-
-        return false;
     }
 
     protected boolean propagateMouseEvent(SpellPart part, double x, double y, double size, double startingAngle, double mouseX, double mouseY, MouseEventHandler callback) {

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -25,12 +25,12 @@ import static dev.enjarai.trickster.render.SpellCircleRenderer.*;
 public class SpellPartWidget extends AbstractParentElement implements Drawable, Selectable {
     public static final double PRECISION_OFFSET = Math.pow(2, 50);
 
-    static final List<Byte> RING_ORDER = List.of(
+    static final Byte[] RING_ORDER = {
         (byte) 0, (byte) 1, (byte) 2, (byte) 5, (byte) 8, (byte) 7, (byte) 6, (byte) 3
-    );
-    static final List<Byte> RING_INDICES = List.of(
+    };
+    static final Byte[] RING_INDICES = {
         (byte) 0, (byte) 1, (byte) 2, (byte) 7, (byte) 0, (byte) 3, (byte) 6, (byte) 5, (byte) 4
-    );
+    };
 
     private SpellPart rootSpellPart;
     private SpellPart spellPart;
@@ -374,10 +374,10 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         if (a == 4 || b == 4) {
             return false;
         } else {
-            var i = RING_INDICES.get(a);
+            var i = RING_INDICES[a];
             return
-                b == RING_ORDER.get((i + 1) % 8) ||
-                b == RING_ORDER.get(i == 0 ? 7 : (i - 1) % 8);
+                b == RING_ORDER[(i + 1) % 8] ||
+                b == RING_ORDER[i == 0 ? 7 : (i - 1) % 8];
         }
     }
 

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -457,7 +457,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
             if (!drawingPattern.isEmpty()) {
                 var last = drawingPattern.get(drawingPattern.size() - 1);
                 if (areAdjacent(last, i)) {
-                    _patternSize += pixelSize * 3.0;
+                    _patternSize += pixelSize * Trickster.CONFIG.adjacentPixelCollisionOffset() * 3;
                 }
             }
 

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -44,7 +44,6 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     private double amountDragged;
     private boolean isMutable = true;
 
-
     @Nullable
     private SpellPart toBeReplaced;
 
@@ -414,7 +413,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                     var move = new ArrayList<Byte>(drawingPattern);
                     // resolve the middle dot if we are going across
                     if (i == 8 - last) {
-                        if (hasEdge(i, (byte) 4)) {
+                        if (hasEdge(i, (byte) 4) || hasEdge(last, (byte) 4)) {
                             // we are already connected to the middle dot
                             // going across is impossible
                             continue;
@@ -444,7 +443,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         var patternSize = size / PATTERN_TO_PART_RATIO;
         var pixelSize = patternSize / PART_PIXEL_RADIUS;
 
-        if (drawingPattern == null){
+        if (drawingPattern == null) {
             drawingPattern = new ArrayList<>();
         }
 

--- a/src/main/java/dev/enjarai/trickster/config/TricksterConfigModel.java
+++ b/src/main/java/dev/enjarai/trickster/config/TricksterConfigModel.java
@@ -4,6 +4,7 @@ import io.wispforest.owo.config.Option;
 import io.wispforest.owo.config.annotation.Config;
 import io.wispforest.owo.config.annotation.Modmenu;
 import io.wispforest.owo.config.annotation.PredicateConstraint;
+import io.wispforest.owo.config.annotation.RangeConstraint;
 import io.wispforest.owo.config.annotation.Sync;
 import io.wispforest.owo.config.annotation.SectionHeader;
 
@@ -27,7 +28,7 @@ public class TricksterConfigModel {
     @Sync(Option.SyncMode.OVERRIDE_CLIENT)
     @PredicateConstraint("requirePositive")
     public float maxBlockBreakingHardness = 55.5f;
-    
+
     @Sync(Option.SyncMode.OVERRIDE_CLIENT)
     public boolean allowSwapBedrock = true;
 
@@ -38,6 +39,9 @@ public class TricksterConfigModel {
 
     @Sync(Option.SyncMode.INFORM_SERVER)
     public boolean disableOffhandScrollOpening = false;
+
+    @RangeConstraint(min = 0, max = 1)
+    public float adjacentPixelCollisionOffset = 0.25f;
 
     public static boolean requirePositive(int value) {
         return value >= 0;

--- a/src/main/resources/assets/trickster/lang/en_us.yml
+++ b/src/main/resources/assets/trickster/lang/en_us.yml
@@ -408,3 +408,4 @@ text.config.trickster-config:
     dragDrawing: Draw by dragging
     barsHorizontal: Show spell-created bars horizontally
     disableOffhandScrollOpening: Require scroll in main hand to edit
+    adjacentPixelCollisionOffset: Offset factor of adjacent pixels


### PR DESCRIPTION
Did two things here:
Rewrote of the glyph selecting function to avoid impossible states like overlapping lines. It generates all valid next moves based on your current pattern and maps them to each dot you can go to. Not the most efficient but easier to reason about (could optimize by caching the moves).

The second is a small bit of trickery to make drawing glyphs feel a little better. The collision checking for neighboring dots is slightly pushed outwards so that going from `1 -> 3` may result less in connecting `1 -> 2` on accident. Additionaly, when drawing around the circle (like for closure glyph), the protruding neighbors help the other way. The effect could be further amplified.