### PR TITLE
Refactor spell view

### DIFF
--- a/src/client/java/dev/enjarai/trickster/screen/ScrollAndQuillScreen.java
+++ b/src/client/java/dev/enjarai/trickster/screen/ScrollAndQuillScreen.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.ScreenHandlerProvider;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.text.Text;
+import org.joml.Vector2d;
 
 import java.util.ArrayList;
 
@@ -104,9 +105,8 @@ public class ScrollAndQuillScreen extends Screen implements ScreenHandlerProvide
     }
 
     record PositionMemory(int spellHash,
-                          double x,
-                          double y,
-                          double size,
+                          Vector2d position,
+                          double radius,
                           SpellPart rootSpellPart,
                           SpellPart spellPart,
                           ArrayList<SpellPart> parents,

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -37,9 +37,8 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     private final Stack<SpellPart> parents = new Stack<>();
     private final Stack<Double> angleOffsets = new Stack<>();
 
-    public double x;
-    public double y;
-    public double size;
+    public Vector2d position;
+    public double radius;
 
     private double amountDragged;
     private boolean isMutable = true;
@@ -55,13 +54,12 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
 
     public final SpellCircleRenderer renderer;
 
-    public SpellPartWidget(SpellPart spellPart, double x, double y, double size, RevisionContext revisionContext, boolean animated) {
+    public SpellPartWidget(SpellPart spellPart, double x, double y, double radius, RevisionContext revisionContext, boolean animated) {
         this.rootSpellPart = spellPart;
         this.spellPart = spellPart;
         this.originalPosition = new Vector2d(toScaledSpace(x), toScaledSpace(y));
-        this.x = toScaledSpace(x);
-        this.y = toScaledSpace(y);
-        this.size = toScaledSpace(size);
+        this.position = new Vector2d(this.originalPosition);
+        this.radius = toScaledSpace(radius);
         this.revisionContext = revisionContext;
         this.renderer = new SpellCircleRenderer(() -> this.drawingPart, () -> this.drawingPattern, PRECISION_OFFSET, animated);
         this.angleOffsets.push(0d);
@@ -107,8 +105,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                 }
 
                 if (failed) {
-                    this.x = originalPosition.x;
-                    this.y = originalPosition.y;
+                    this.position = new Vector2d(originalPosition);
                     break;
                 }
             }
@@ -125,13 +122,16 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     }
 
     public ScrollAndQuillScreen.PositionMemory save() {
-        return new ScrollAndQuillScreen.PositionMemory(rootSpellPart.hashCode(), x, y, size, rootSpellPart, spellPart, new ArrayList<>(parents), new ArrayList<>(angleOffsets));
+        return new ScrollAndQuillScreen.PositionMemory(
+            rootSpellPart.hashCode(),
+            position.x, position.y, radius,
+            rootSpellPart, spellPart,
+            new ArrayList<>(parents), new ArrayList<>(angleOffsets));
     }
 
     public void load(ScrollAndQuillScreen.PositionMemory memory) {
-        this.x = memory.x();
-        this.y = memory.y();
-        this.size = memory.size();
+        this.position = new Vector2d(memory.x(), memory.y());
+        this.radius = memory.size();
         this.rootSpellPart = memory.rootSpellPart();
         this.spellPart = memory.spellPart();
         this.parents.clear();
@@ -148,11 +148,10 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
 
         //        context.getMatrices().push();
         //        context.getMatrices().scale((float) PRECISION_OFFSET, (float) PRECISION_OFFSET, (float) PRECISION_OFFSET);
-
         this.renderer.renderPart(
                 context.getMatrices(), context.getVertexConsumers(), spellPart,
-                x, y, size, angleOffsets.peek(), delta,
-                size -> (float) Math.clamp(1 / (size / context.getScaledWindowHeight() * 3) - 0.2, 0, 1),
+                position.x, position.y, radius, angleOffsets.peek(), delta,
+                radius -> (float) Math.clamp(1 / (radius / context.getScaledWindowHeight() * 3), 0.0, 0.8),
                 new Vec3d(-1, 0, 0)
         );
         context.draw();
@@ -160,8 +159,8 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         //        context.getMatrices().pop();
     }
 
-    public static boolean isCircleClickable(double size) {
-        return size >= 16 && size <= 256;
+    public static boolean isCircleClickable(double radius) {
+        return radius >= 16 && radius <= 256;
     }
 
     @Override
@@ -192,14 +191,19 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
             return true;
         }
 
-        size += verticalAmount * size / 10;
-        x += verticalAmount * (x - toScaledSpace(mouseX)) / 10;
-        y += verticalAmount * (y - toScaledSpace(mouseY)) / 10;
+        Vector2d scaledMouse = toScaledSpace(new Vector2d(mouseX, mouseY));
+        position.add(new Vector2d(position).sub(scaledMouse).mul(verticalAmount / 10));
+        radius += verticalAmount * radius / 10;
 
-        if (toLocalSpace(size) > 600) {
-            pushNewRoot(toScaledSpace(mouseX), toScaledSpace(mouseY));
-        } else if (toLocalSpace(size) < 300 && !parents.empty()) {
-            popOldRoot();
+        var subRadius = toLocalSpace(spellPart.subRadius(radius));
+        if(verticalAmount > 0) {
+            if (subRadius > 600 && (spellPart.glyph instanceof SpellPart || spellPart.partCount() > 0)) {
+                pushNewRoot(scaledMouse);
+            }
+        } else {
+            if (subRadius < 300 && !parents.empty()) {
+                popOldRoot();
+            }
         }
 
         return true;
@@ -210,17 +214,16 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         angleOffsets.pop();
 
         int partCount = result.subParts.size();
-        var parentSize = size * 3;
+        var parentSize = radius * 3;
         int i = 0;
 
         if (!(result.glyph instanceof SpellPart inner && inner == spellPart)) {
-            parentSize = Math.max(size * 2, size * (double) ((partCount + 1) / 2));
+            parentSize = Math.max(radius * 2, radius * (double) ((partCount + 1) / 2));
 
             for (var child : result.subParts) {
                 if (child == spellPart) {
-                    var angle = angleOffsets.peek() + (2 * Math.PI) / partCount * i - (Math.PI / 2);
-                    x -= parentSize * Math.cos(angle);
-                    y -= parentSize * Math.sin(angle);
+                    var subPos = result.subPosition(i, parentSize, angleOffsets.peek());
+                    position.sub(subPos);
                     break;
                 }
 
@@ -228,58 +231,27 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
             }
         }
 
-        size = parentSize;
+        radius = parentSize;
         spellPart = result;
     }
 
-    private void pushNewRoot(double mouseX, double mouseY) {
-        var closest = spellPart;
-        var closestAngle = angleOffsets.peek();
-        var closestDiffX = 0d;
-        var closestDiffY = 0d;
-        var closestDistanceSquared = Double.MAX_VALUE;
-        var closestSize = size / 3;
-
-        int partCount = spellPart.subParts.size();
-        var nextSize = Math.min(size / 2, size / (double) ((partCount + 1) / 2));
-        int i = 0;
-
-        if (spellPart.glyph instanceof SpellPart inner) {
-            var mDiffX = x - mouseX;
-            var mDiffY = y - mouseY;
-            var distanceSquared = mDiffX * mDiffX + mDiffY * mDiffY;
-            closest = inner;
-            closestDistanceSquared = distanceSquared;
-        }
-
-        for (var child : spellPart.subParts) {
-            var angle = angleOffsets.peek() + (2 * Math.PI) / partCount * i - (Math.PI / 2);
-            var nextX = x + (size * Math.cos(angle));
-            var nextY = y + (size * Math.sin(angle));
-            var diffX = nextX - x;
-            var diffY = nextY - y;
-            var mDiffX = nextX - mouseX;
-            var mDiffY = nextY - mouseY;
-            var distanceSquared = mDiffX * mDiffX + mDiffY * mDiffY;
-
-            if (distanceSquared < closestDistanceSquared) {
-                closest = child;
-                closestAngle = angle;
-                closestDiffX = diffX;
-                closestDiffY = diffY;
-                closestDistanceSquared = distanceSquared;
-                closestSize = nextSize;
+    private void pushNewRoot(Vector2d scaledMouse) {
+        double angle = angleOffsets.peek();
+        int closestIndex = spellPart.closestIndex(position, scaledMouse, radius, angle);
+        if (closestIndex == -1) {
+            this.radius = radius / 3;
+            this.angleOffsets.push(angle);
+            this.parents.push(spellPart);
+            if (spellPart.glyph instanceof SpellPart inner) {
+                this.spellPart = inner;
             }
-
-            i++;
+        } else {
+            this.position.add(spellPart.subPosition(closestIndex, radius, angle));
+            this.radius = spellPart.subRadius(radius);
+            this.angleOffsets.push(spellPart.subAngle(closestIndex, angle));
+            this.parents.push(spellPart);
+            this.spellPart = spellPart.subParts.get(closestIndex);
         }
-
-        this.parents.push(spellPart);
-        this.angleOffsets.push(closestAngle);
-        this.spellPart = closest;
-        this.size = closestSize;
-        this.x += closestDiffX;
-        this.y += closestDiffY;
     }
 
     @Override
@@ -289,9 +261,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         }
 
         if (!isDrawing()) {
-            x += toScaledSpace(deltaX);
-            y += toScaledSpace(deltaY);
-
+            position.add(toScaledSpace(new Vector2d(deltaX, deltaY)));
             amountDragged += Math.abs(deltaX) + Math.abs(deltaY);
             return true;
         }
@@ -303,24 +273,9 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         if (isMutable || isDrawing()) {
             if (Trickster.CONFIG.dragDrawing() && button == 0 && !isDrawing()) {
-                if (
-                    propagateMouseEvent(
-                            spellPart, x, y, size, angleOffsets.peek(), toScaledSpace(mouseX), toScaledSpace(mouseY),
-                            (part, x, y, size) -> selectPattern(part, x, y, size, mouseX, mouseY)
-                    )
-                ) {
-                    return true;
-                }
+                propagateMouseEvent(mouseX, mouseY, this::selectPattern);
             } else {
-                // We need to return true on the mouse down event to make sure the screen knows if we're on a clickable node
-                if (
-                    propagateMouseEvent(
-                            spellPart, x, y, size, angleOffsets.peek(), toScaledSpace(mouseX), toScaledSpace(mouseY),
-                            (part, x, y, size) -> true
-                    )
-                ) {
-                    return true;
-                }
+                propagateMouseEvent(mouseX, mouseY, (part, pos, rad, mouse) -> true);
             }
         }
 
@@ -338,12 +293,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
             }
 
             if (!Trickster.CONFIG.dragDrawing() && button == 0 && !isDrawing()) {
-                if (
-                    propagateMouseEvent(
-                            spellPart, x, y, size, angleOffsets.peek(), toScaledSpace(mouseX), toScaledSpace(mouseY),
-                            (part, x, y, size) -> selectPattern(part, x, y, size, mouseX, mouseY)
-                    )
-                ) {
+                if (propagateMouseEvent(mouseX, mouseY, this::selectPattern)) {
                     return true;
                 }
             }
@@ -360,10 +310,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     @Override
     public void mouseMoved(double mouseX, double mouseY) {
         if (isDrawing()) {
-            propagateMouseEvent(
-                    spellPart, x, y, size, angleOffsets.peek(), toScaledSpace(mouseX), toScaledSpace(mouseY),
-                    (part, x, y, size) -> selectPattern(part, x, y, size, mouseX, mouseY)
-            );
+            propagateMouseEvent(mouseX, mouseY, this::selectPattern);
         }
 
         super.mouseMoved(mouseX, mouseY);
@@ -434,14 +381,14 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     }
 
     @SuppressWarnings("resource")
-    protected boolean selectPattern(SpellPart part, float x, float y, float size, double mouseX, double mouseY) {
+    protected boolean selectPattern(SpellPart part, Vector2d position, float radius, Vector2d mouse) {
         if (drawingPart != null && drawingPart != part) {
             // Cancel early if we're already drawing in another part
             return false;
         }
 
-        var patternSize = size / PATTERN_TO_PART_RATIO;
-        var pixelSize = patternSize / PART_PIXEL_RADIUS;
+        var patternRadius = radius / PATTERN_TO_PART_RATIO;
+        var pixelSize = patternRadius / PART_PIXEL_RADIUS;
 
         if (drawingPattern == null) {
             drawingPattern = new ArrayList<>();
@@ -453,17 +400,17 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
             // if we are checking the closest neighboring dots on the ring
             // translate the dots outward a bit by enlarging the radius
             // this will make it easier to connect lines to the next neighbors on the ring
-            var _patternSize = patternSize;
+            var _patternRadius = patternRadius;
             if (!drawingPattern.isEmpty()) {
                 var last = drawingPattern.get(drawingPattern.size() - 1);
                 if (areAdjacent(last, i)) {
-                    _patternSize += pixelSize * Trickster.CONFIG.adjacentPixelCollisionOffset() * 3;
+                    _patternRadius += pixelSize * Trickster.CONFIG.adjacentPixelCollisionOffset() * 3;
                 }
             }
 
-            var pos = getPatternDotPosition(x, y, i, _patternSize);
+            var pos = getPatternDotPosition((float) position.x, (float) position.y, i, _patternRadius);
 
-            if (isInsideHitbox(pos, pixelSize, mouseX, mouseY)) {
+            if (isInsideHitbox(pos, pixelSize, mouse.x, mouse.y)) {
                 if (drawingPart == null) {
                     drawingPart = part;
                     oldGlyph = part.glyph;
@@ -560,59 +507,48 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         return drawingPart != null;
     }
 
-    protected boolean propagateMouseEvent(SpellPart part, double x, double y, double size, double startingAngle, double mouseX, double mouseY, MouseEventHandler callback) {
-        var closest = part;
-        var closestAngle = startingAngle;
-        var closestX = x;
-        var closestY = y;
-        var closestSize = size;
+    protected boolean propagateMouseEvent(double mouseX, double mouseY, MouseEventHandler callback) {
+        return propagateMouseEvent(spellPart, position, radius, angleOffsets.peek(), toScaledSpace(new Vector2d(mouseX, mouseY)), callback);
+    }
+    
+    protected boolean propagateMouseEvent(SpellPart part, Vector2d pos, double radius, double startingAngle, Vector2d mouse, MouseEventHandler callback) {
+        int closestIndex = part.closestIndex(pos, mouse, radius, startingAngle);
+        boolean centerAvailable =
+            (isCircleClickable(toLocalSpace(radius)) && (drawingPart == null || drawingPart == part))
+            || part.glyph instanceof SpellPart;
 
-        var centerAvailable = (isCircleClickable(toLocalSpace(size)) && (drawingPart == null || drawingPart == part)) || part.glyph instanceof SpellPart;
-        var closestDistanceSquared = Double.MAX_VALUE;
-
-        int partCount = part.getSubParts().size();
-        // We dont change this, its the same for all subcircles
-        var nextSize = Math.min(size / 2, size / (double) ((partCount + 1) / 2));
-        int i = 0;
-        for (var child : part.getSubParts()) {
-            var angle = startingAngle + (2 * Math.PI) / partCount * i - (Math.PI / 2);
-
-            var nextX = x + (size * Math.cos(angle));
-            var nextY = y + (size * Math.sin(angle));
-            var diffX = nextX - mouseX;
-            var diffY = nextY - mouseY;
-            var distanceSquared = diffX * diffX + diffY * diffY;
-
-            if (distanceSquared < closestDistanceSquared) {
-                closest = child;
-                closestAngle = angle;
-                closestX = nextX;
-                closestY = nextY;
-                closestSize = nextSize;
-                closestDistanceSquared = distanceSquared;
-            }
-
-            i++;
+        SpellPart closest = part;
+        double closestDistanceSquared = Double.MAX_VALUE;
+        Vector2d closestPosition = pos;
+        double closestRadius = radius;
+        double closestAngle = startingAngle;
+        
+        if (closestIndex > -1) {
+            closest = part.subParts.get(closestIndex);
+            closestPosition = part.subPosition(closestIndex, radius, startingAngle).add(pos);
+            closestDistanceSquared = closestPosition.distanceSquared(mouse);
+            closestAngle = part.subAngle(closestIndex, startingAngle);
+            closestRadius = part.subRadius(radius);
         }
 
         if (centerAvailable) {
-            if (part.glyph instanceof SpellPart centerPart) {
-                if (propagateMouseEvent(centerPart, x, y, size / 3, startingAngle, mouseX, mouseY, callback)) {
+            if (part.glyph instanceof SpellPart inner) {
+                if (propagateMouseEvent(inner, pos, radius / 3, startingAngle, mouse, callback)) {
                     return true;
                 }
             } else {
-                if (callback.handle(part, toLocalSpace(x), toLocalSpace(y), toLocalSpace(size))) {
+                if (callback.handle(part, toLocalSpace(pos), toLocalSpace(radius), toLocalSpace(mouse))) {
                     return true;
                 }
             }
         }
 
-        if (Math.sqrt(closestDistanceSquared) <= size && toLocalSpace(size) >= 16) {
+        if (Math.sqrt(closestDistanceSquared) <= radius && toLocalSpace(radius) >= 16) {
             if (closest == part) {
                 return false;
             }
 
-            return propagateMouseEvent(closest, closestX, closestY, closestSize, closestAngle, mouseX, mouseY, callback);
+            return propagateMouseEvent(closest, closestPosition, closestRadius, closestAngle, mouse, callback);
         }
 
         return false;
@@ -626,38 +562,46 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         return value / PRECISION_OFFSET;
     }
 
+    private static Vector2d toLocalSpace(Vector2d value) {
+        return new Vector2d(value).mul(PRECISION_OFFSET);
+    }
+
+    private static Vector2d toScaledSpace(Vector2d value) {
+        return new Vector2d(value).div(PRECISION_OFFSET);
+    }
+
     interface MouseEventHandler {
-        boolean handle(SpellPart part, float x, float y, float size);
+        boolean handle(SpellPart part, Vector2d pos, float radius, Vector2d mouse);
     }
 
     //    @Override
     //    public void setX(int x) {
-    //        this.x = x + size;
+    //        this.x = x + radius;
     //    }
     //
     //    @Override
     //    public void setY(int y) {
-    //        this.y = y + size;
+    //        this.y = y + radius;
     //    }
     //
     //    @Override
     //    public int getX() {
-    //        return (int) (x - size);
+    //        return (int) (x - radius);
     //    }
     //
     //    @Override
     //    public int getY() {
-    //        return (int) (y - size);
+    //        return (int) (y - radius);
     //    }
     //
     //    @Override
     //    public int getWidth() {
-    //        return (int) size * 2;
+    //        return (int) radius * 2;
     //    }
     //
     //    @Override
     //    public int getHeight() {
-    //        return (int) size * 2;
+    //        return (int) radius * 2;
     //    }
     //
     //    @Override

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -220,16 +220,16 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         var result = parents.pop();
         angleOffsets.pop();
 
-        int partCount = result.subParts.size();
-        var parentSize = radius * 3;
+        int partCount = result.partCount();
+        var parentRadius = radius * 3;
         int i = 0;
 
         if (!(result.glyph instanceof SpellPart inner && inner == spellPart)) {
-            parentSize = Math.max(radius * 2, radius * (double) ((partCount + 1) / 2));
+            parentRadius = Math.max(radius * 2, radius * (double) ((partCount + 1) / 2));
 
             for (var child : result.subParts) {
                 if (child == spellPart) {
-                    var subPos = result.subPosition(i, parentSize, angleOffsets.peek());
+                    var subPos = result.subPosition(i, parentRadius, angleOffsets.peek());
                     position.sub(subPos);
                     break;
                 }
@@ -238,7 +238,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
             }
         }
 
-        radius = parentSize;
+        radius = parentRadius;
         spellPart = result;
     }
 

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -24,6 +24,10 @@ import static dev.enjarai.trickster.render.SpellCircleRenderer.*;
 
 public class SpellPartWidget extends AbstractParentElement implements Drawable, Selectable {
     public static final double PRECISION_OFFSET = Math.pow(2, 50);
+    public static final double ZOOM_SPEED = 0.1;
+
+    static final Byte MIDDLE_DOT = 4;
+    static final Byte DOT_COUNT = 9;
 
     static final Byte[] RING_ORDER = {
             (byte) 0, (byte) 1, (byte) 2, (byte) 5, (byte) 8, (byte) 7, (byte) 6, (byte) 3
@@ -195,8 +199,8 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         }
 
         Vector2d scaledMouse = toScaledSpace(new Vector2d(mouseX, mouseY));
-        position.add(new Vector2d(position).sub(scaledMouse).mul(verticalAmount / 10));
-        radius += verticalAmount * radius / 10;
+        position.add(new Vector2d(position).sub(scaledMouse).mul(verticalAmount * ZOOM_SPEED));
+        radius += verticalAmount * radius * ZOOM_SPEED;
 
         var subRadius = toLocalSpace(spellPart.subRadius(radius));
         if(verticalAmount > 0) {
@@ -320,7 +324,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     }
 
     private static boolean areAdjacent(byte a, byte b) {
-        if (a == 4 || b == 4) {
+        if (a == MIDDLE_DOT || b == MIDDLE_DOT) {
             return false;
         } else {
             var i = RING_INDICES[a];
@@ -347,14 +351,14 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     private HashMap<Byte, List<Byte>> possibleMoves() {
         var moves = new HashMap<Byte, List<Byte>>();
         if (drawingPattern.isEmpty()) {
-            for (byte i = 0; i < 9; i++) {
+            for (byte i = 0; i < DOT_COUNT; i++) {
                 var move = new ArrayList<Byte>();
                 move.add(i);
                 moves.put(i, move);
             }
         } else {
             var last = drawingPattern.getLast();
-            for (byte i = 0; i < 9; i++) {
+            for (byte i = 0; i < DOT_COUNT; i++) {
                 if (i == last) {
                     continue;
                 }
@@ -363,12 +367,12 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
                     var move = new ArrayList<Byte>(drawingPattern);
                     // resolve the middle dot if we are going across
                     if (i == 8 - last) {
-                        if (hasLine(i, (byte) 4) || hasLine(last, (byte) 4)) {
+                        if (hasLine(i, MIDDLE_DOT) || hasLine(last, MIDDLE_DOT)) {
                             // we are already connected to the middle dot
                             // going across is impossible
                             continue;
                         } else {
-                            move.add((byte) 4);
+                            move.add(MIDDLE_DOT);
                         }
                     }
                     move.add(i);
@@ -399,7 +403,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
 
         var moves = possibleMoves();
 
-        for (byte i = 0; i < 9; i++) {
+        for (byte i = 0; i < DOT_COUNT; i++) {
             // if we are checking the closest neighboring dots on the ring
             // translate the dots outward a bit by enlarging the radius
             // this will make it easier to connect lines to the next neighbors on the ring

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -124,14 +124,14 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     public ScrollAndQuillScreen.PositionMemory save() {
         return new ScrollAndQuillScreen.PositionMemory(
             rootSpellPart.hashCode(),
-            position.x, position.y, radius,
+            position, radius,
             rootSpellPart, spellPart,
             new ArrayList<>(parents), new ArrayList<>(angleOffsets));
     }
 
     public void load(ScrollAndQuillScreen.PositionMemory memory) {
-        this.position = new Vector2d(memory.x(), memory.y());
-        this.radius = memory.size();
+        this.position = memory.position();
+        this.radius = memory.radius();
         this.rootSpellPart = memory.rootSpellPart();
         this.spellPart = memory.spellPart();
         this.parents.clear();

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -39,6 +39,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
 
     public Vector2d position;
     public double radius;
+    public double windowHeight = 600;
 
     private double amountDragged;
     private boolean isMutable = true;
@@ -148,10 +149,11 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
 
         //        context.getMatrices().push();
         //        context.getMatrices().scale((float) PRECISION_OFFSET, (float) PRECISION_OFFSET, (float) PRECISION_OFFSET);
+        windowHeight = context.getScaledWindowHeight();
         this.renderer.renderPart(
                 context.getMatrices(), context.getVertexConsumers(), spellPart,
                 position.x, position.y, radius, angleOffsets.peek(), delta,
-                radius -> (float) Math.clamp(1 / (radius / context.getScaledWindowHeight() * 3), 0.0, 0.8),
+                radius -> (float) Math.clamp(1 / (radius / windowHeight * 3), 0.0, 0.8),
                 new Vec3d(-1, 0, 0)
         );
         context.draw();
@@ -159,6 +161,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         //        context.getMatrices().pop();
     }
 
+    // TODO this still depends on the GUI scale, should be a ratio of the scaled window height of the context
     public static boolean isCircleClickable(double radius) {
         return radius >= 16 && radius <= 256;
     }
@@ -197,11 +200,11 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
 
         var subRadius = toLocalSpace(spellPart.subRadius(radius));
         if(verticalAmount > 0) {
-            if (subRadius > 600 && (spellPart.glyph instanceof SpellPart || spellPart.partCount() > 0)) {
+            if (subRadius > windowHeight && (spellPart.glyph instanceof SpellPart || spellPart.partCount() > 0)) {
                 pushNewRoot(scaledMouse);
             }
         } else {
-            if (subRadius < 300 && !parents.empty()) {
+            if (subRadius < windowHeight / 2 && !parents.empty()) {
                 popOldRoot();
             }
         }

--- a/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
+++ b/src/client/java/dev/enjarai/trickster/screen/SpellPartWidget.java
@@ -244,7 +244,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
 
     private void pushNewRoot(Vector2d scaledMouse) {
         double angle = angleOffsets.peek();
-        int closestIndex = spellPart.closestIndex(position, scaledMouse, radius, angle);
+        int closestIndex = closestIndex(spellPart, position, scaledMouse, radius, angle);
         if (closestIndex == -1) {
             this.radius = radius / 3;
             this.angleOffsets.push(angle);
@@ -321,6 +321,28 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
         }
 
         super.mouseMoved(mouseX, mouseY);
+    }
+
+    // returns the index of the closest sub-circle from the mouse or -1 if the center is the closest
+    private static int closestIndex(SpellPart part, Vector2d position, Vector2d mouse, double radius, double angleOffset) {
+        int closest = -1;
+        double closestDistanceSquared = Double.MAX_VALUE;
+
+        if (part.glyph instanceof SpellPart) {
+            closestDistanceSquared = position.distanceSquared(mouse);
+        }
+
+        for (int i = 0; i < part.partCount(); i++) {
+            Vector2d subPos = part.subPosition(i, radius, angleOffset).add(position);
+            double distanceSquared = subPos.distanceSquared(mouse);
+
+            if (distanceSquared < closestDistanceSquared) {
+                closest = i;
+                closestDistanceSquared = distanceSquared;
+            }
+        }
+
+        return closest;
     }
 
     private static boolean areAdjacent(byte a, byte b) {
@@ -519,7 +541,7 @@ public class SpellPartWidget extends AbstractParentElement implements Drawable, 
     }
     
     protected boolean propagateMouseEvent(SpellPart part, Vector2d pos, double radius, double startingAngle, Vector2d mouse, MouseEventHandler callback) {
-        int closestIndex = part.closestIndex(pos, mouse, radius, startingAngle);
+        int closestIndex = closestIndex(part, pos, mouse, radius, startingAngle);
         boolean centerAvailable =
             (isCircleClickable(toLocalSpace(radius)) && (drawingPart == null || drawingPart == part))
             || part.glyph instanceof SpellPart;

--- a/src/main/java/dev/enjarai/trickster/spell/SpellPart.java
+++ b/src/main/java/dev/enjarai/trickster/spell/SpellPart.java
@@ -263,26 +263,4 @@ public final class SpellPart implements Fragment {
         double angle = this.subAngle(index, angleOffset);
         return new Vector2d(Math.cos(angle), Math.sin(angle)).mul(radius);
     }
-
-    // returns the index of the closest sub-circle from the mouse or -1 if the center is the closest
-    public int closestIndex(Vector2d position, Vector2d mouse, double radius, double angleOffset) {
-        int closest = -1;
-        double closestDistanceSquared = Double.MAX_VALUE;
-
-        if (this.glyph instanceof SpellPart) {
-            closestDistanceSquared = position.distanceSquared(mouse);
-        }
-
-        for (int i = 0; i < this.partCount(); i++) {
-            Vector2d subPos = this.subPosition(i, radius, angleOffset).add(position);
-            double distanceSquared = subPos.distanceSquared(mouse);
-
-            if (distanceSquared < closestDistanceSquared) {
-                closest = i;
-                closestDistanceSquared = distanceSquared;
-            }
-        }
-
-        return closest;
-    }
 }

--- a/src/main/java/dev/enjarai/trickster/spell/SpellPart.java
+++ b/src/main/java/dev/enjarai/trickster/spell/SpellPart.java
@@ -20,6 +20,7 @@ import io.wispforest.endec.StructEndec;
 import io.wispforest.endec.format.bytebuf.ByteBufDeserializer;
 import io.wispforest.endec.impl.StructEndecBuilder;
 import net.minecraft.text.Text;
+import org.joml.Vector2d;
 
 public final class SpellPart implements Fragment {
     public static final StructEndec<SpellPart> ENDEC = EndecTomfoolery.recursive(
@@ -244,5 +245,44 @@ public final class SpellPart implements Fragment {
         }
 
         return result;
+    }
+
+    public int partCount() {
+        return subParts.size();
+    }
+
+    public double subRadius(double radius) {
+        return Math.min(radius / 2, radius / (double) ((this.partCount() + 1) / 2));
+    }
+
+    public double subAngle(int index, double angleOffset) {
+        return angleOffset + (2 * Math.PI) / this.partCount() * index - (Math.PI / 2);
+    }
+
+    public Vector2d subPosition(int index, double radius, double angleOffset) {
+        double angle = this.subAngle(index, angleOffset);
+        return new Vector2d(Math.cos(angle), Math.sin(angle)).mul(radius);
+    }
+
+    // returns the index of the closest sub-circle from the mouse or -1 if the center is the closest
+    public int closestIndex(Vector2d position, Vector2d mouse, double radius, double angleOffset) {
+        int closest = -1;
+        double closestDistanceSquared = Double.MAX_VALUE;
+
+        if (this.glyph instanceof SpellPart) {
+            closestDistanceSquared = position.distanceSquared(mouse);
+        }
+
+        for (int i = 0; i < this.partCount(); i++) {
+            Vector2d subPos = this.subPosition(i, radius, angleOffset).add(position);
+            double distanceSquared = subPos.distanceSquared(mouse);
+
+            if (distanceSquared < closestDistanceSquared) {
+                closest = i;
+                closestDistanceSquared = distanceSquared;
+            }
+        }
+
+        return closest;
     }
 }


### PR DESCRIPTION
A bit of cleanup for the future

* `size` renamed to `radius` to better describe what it is
* `x` `y` moved to `position` for simpler Vector2d operations
* calculations around subcircles extracted to SpellPart
* some functions have been simplified as a result
* fixing #115 by doing two things:
  1. pushing and popping roots only happens at the appropriate direction of scroll (we should never pop when zooming in and vice versa), this gets rid of the flicker
  2. instead of thresholding on the radius of the current root, we threshold on the radius of its subcircles, this makes it so the threshold is applied the same way regardless of how many subcircles the current root has and subcircles with many siblings won't get pushed as root prematurely