### PR TITLE
Fix text offset in circles

### DIFF
--- a/src/client/java/dev/enjarai/trickster/render/fragment/FragmentRenderer.java
+++ b/src/client/java/dev/enjarai/trickster/render/fragment/FragmentRenderer.java
@@ -2,7 +2,6 @@ package dev.enjarai.trickster.render.fragment;
 
 import dev.enjarai.trickster.Trickster;
 
-
 import dev.enjarai.trickster.render.SpellCircleRenderer;
 import dev.enjarai.trickster.spell.Fragment;
 import dev.enjarai.trickster.spell.fragment.FragmentType;
@@ -24,7 +23,7 @@ public interface FragmentRenderer<T extends Fragment> {
     PatternLiteralRenderer PATTERN_LITERAL = register(FragmentType.PATTERN_LITERAL, new PatternLiteralRenderer());
     ItemTypeRenderer ITEM_TYPE = register(FragmentType.ITEM_TYPE, new ItemTypeRenderer());
     BlockTypeRenderer BLOCK_TYPE = register(FragmentType.BLOCK_TYPE, new BlockTypeRenderer());
-//    EntityRenderer ENTITY = register(FragmentType.ENTITY, new EntityRenderer());
+    // EntityRenderer ENTITY = register(FragmentType.ENTITY, new EntityRenderer());
 
     static <T extends FragmentRenderer<F>, F extends Fragment> T register(FragmentType<F> type, T renderer) {
         return Registry.register(REGISTRY, FragmentType.REGISTRY.getId(type), renderer);
@@ -32,23 +31,23 @@ public interface FragmentRenderer<T extends Fragment> {
 
     static void register() {}
 
-    static void renderAsText(Fragment fragment, MatrixStack matrices, VertexConsumerProvider vertexConsumers, float x, float y, float size, float alpha) {
+    static void renderAsText(Fragment fragment, MatrixStack matrices, VertexConsumerProvider vertexConsumers, float x, float y, float radius, float alpha) {
         var textRenderer = MinecraftClient.getInstance().textRenderer;
 
-//            var height = textRenderer.wrapLines(Text.literal(glyph.asString()), ) // TODO
+        // var height = textRenderer.wrapLines(Text.literal(glyph.asString()), ) // TODO
         var text = fragment.asFormattedText();
         var height = 7;
         var width = textRenderer.getWidth(text);
 
         matrices.push();
         matrices.translate(x, y, 0);
-        matrices.scale(size / 1.3f / width, size / 1.3f / width, 1);
+        matrices.scale(radius / 1.3f / width, radius / 1.3f / width, 1);
 
         var color = ColorHelper.Argb.withAlpha((int) (alpha * 0xff), 0xffffff);
 
         textRenderer.draw(
                 text,
-                -width / 2f, -height / 2f, color, false,
+                -(width - 1f) / 2f, -height / 2f, color, false,
                 matrices.peek().getPositionMatrix(),
                 vertexConsumers, TextRenderer.TextLayerType.NORMAL,
                 0, 0xf000f0
@@ -57,7 +56,7 @@ public interface FragmentRenderer<T extends Fragment> {
         matrices.pop();
     }
 
-    void render(T fragment, MatrixStack matrices, VertexConsumerProvider vertexConsumers, float x, float y, float size, float alpha, Vec3d normal, float tickDelta, SpellCircleRenderer delegator);
+    void render(T fragment, MatrixStack matrices, VertexConsumerProvider vertexConsumers, float x, float y, float radius, float alpha, Vec3d normal, float tickDelta, SpellCircleRenderer delegator);
 
     default boolean renderRedrawDots() {
         return true;


### PR DESCRIPTION
The rendering was off by half a pixel for `renderAsText`. Corrected this and renamed `size` here to `radius` to follow the last circles refactor.

Before

https://github.com/user-attachments/assets/d14410da-0116-4428-81ea-8721011469d1

After

https://github.com/user-attachments/assets/c064eb01-1e69-4460-99ac-97c07fc59245

