### PR TITLE
Generalize Notulist's conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Updated the entry for the Notulist's Delusion to Notulist's Ingress. (@aurakle)
 - Added a tax to the Conduit's Ploy. (@aurakle)
 - Made slot move cost more precise. (@aurakle)
+- Generalized Notulist's item conversions. (@aurakle)

--- a/src/main/java/dev/enjarai/trickster/item/component/FragmentComponent.java
+++ b/src/main/java/dev/enjarai/trickster/item/component/FragmentComponent.java
@@ -1,6 +1,7 @@
 package dev.enjarai.trickster.item.component;
 
 import dev.enjarai.trickster.EndecTomfoolery;
+import dev.enjarai.trickster.Trickster;
 import dev.enjarai.trickster.advancement.criterion.ModCriteria;
 import dev.enjarai.trickster.item.ModItems;
 import dev.enjarai.trickster.spell.Fragment;
@@ -242,13 +243,19 @@ public record FragmentComponent(Fragment value, Optional<Text> name, boolean imm
         return getUserMergedMap(user, type).orElseGet(otherwise);
     }
 
-    public static void registerNotulistWriteConversion(Item type, Function1<ItemStack, ItemStack> onWrite) {
-        customWriteBehaviors.put(type, onWrite);
-        //TODO: override warning?
+    public static void registerWriteConversion(Item type, Function1<ItemStack, ItemStack> onWrite) {
+        var old = customWriteBehaviors.put(type, onWrite);
+        if (old != null) {
+            //TODO: this could be improved, translations aren't loaded for modded items
+            Trickster.LOGGER.warn("Fragment write conversion for \"{}\" has been overriden", type.getName().getString());
+        }
     }
 
-    public static void registerNotulistResetConversion(Item type, Function1<ItemStack, ItemStack> onReset) {
-        customResetBehaviors.put(type, onReset);
-        //TODO: override warning?
+    public static void registerResetConversion(Item type, Function1<ItemStack, ItemStack> onReset) {
+        var old = customResetBehaviors.put(type, onReset);
+        if (old != null) {
+            //TODO: this could be improved, translations aren't loaded for modded items
+            Trickster.LOGGER.warn("Fragment reset conversion for \"{}\" has been overriden", type.getName().getString());
+        }
     }
 }

--- a/src/main/java/dev/enjarai/trickster/item/component/ModComponents.java
+++ b/src/main/java/dev/enjarai/trickster/item/component/ModComponents.java
@@ -49,10 +49,10 @@ public class ModComponents {
     }
 
     public static void register() {
-        FragmentComponent.registerNotulistWriteConversion(Items.BOOK,
+        FragmentComponent.registerWriteConversion(Items.BOOK,
                 stack -> stack.withItem(Items.ENCHANTED_BOOK)
         );
-        FragmentComponent.registerNotulistResetConversion(Items.ENCHANTED_BOOK,
+        FragmentComponent.registerResetConversion(Items.ENCHANTED_BOOK,
                 stack -> stack.get(DataComponentTypes.STORED_ENCHANTMENTS) instanceof ItemEnchantmentsComponent enchants && enchants.isEmpty()
                         ? stack.withItem(Items.BOOK)
                         : stack

--- a/src/main/java/dev/enjarai/trickster/item/component/ModComponents.java
+++ b/src/main/java/dev/enjarai/trickster/item/component/ModComponents.java
@@ -3,6 +3,9 @@ package dev.enjarai.trickster.item.component;
 import dev.enjarai.trickster.EndecTomfoolery;
 import dev.enjarai.trickster.Trickster;
 import net.minecraft.component.ComponentType;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 
@@ -46,6 +49,13 @@ public class ModComponents {
     }
 
     public static void register() {
-
+        FragmentComponent.registerNotulistWriteConversion(Items.BOOK,
+                stack -> stack.withItem(Items.ENCHANTED_BOOK)
+        );
+        FragmentComponent.registerNotulistResetConversion(Items.ENCHANTED_BOOK,
+                stack -> stack.get(DataComponentTypes.STORED_ENCHANTMENTS) instanceof ItemEnchantmentsComponent enchants && enchants.isEmpty()
+                        ? stack.withItem(Items.BOOK)
+                        : stack
+        );
     }
 }


### PR DESCRIPTION
Adds registration for `ItemStack -> ItemStack` conversions to be applied on a successful write/reset of the fragment component. This removes the `BOOK` and `ENCHANTED_BOOK` special-case.