### PR TITLE
let the creative-only spell editing hotkey have access to macros

### DIFF
--- a/src/main/java/dev/enjarai/trickster/net/SpellEditPacket.java
+++ b/src/main/java/dev/enjarai/trickster/net/SpellEditPacket.java
@@ -1,6 +1,7 @@
 package dev.enjarai.trickster.net;
 
 import dev.enjarai.trickster.item.ModItems;
+import dev.enjarai.trickster.item.component.FragmentComponent;
 import dev.enjarai.trickster.screen.ScrollAndQuillScreenHandler;
 import io.vavr.collection.HashMap;
 import io.wispforest.owo.network.ServerAccess;
@@ -21,6 +22,8 @@ public record SpellEditPacket() {
 
         if (stack.isEmpty()) return;
 
+        var mergedMap = FragmentComponent.getUserMergedMap(player, "ring", HashMap::empty);
+
         player.openHandledScreen(new NamedScreenHandlerFactory() {
             @Override
             public Text getDisplayName() {
@@ -30,8 +33,8 @@ public record SpellEditPacket() {
             @Override
             public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
                 return new ScrollAndQuillScreenHandler(
-                  syncId, playerInventory, stack, player.getOffHandStack(), EquipmentSlot.MAINHAND,
-                  HashMap.empty(), stack.isOf(ModItems.MIRROR_OF_EVALUATION), true
+                        syncId, playerInventory, stack, player.getOffHandStack(), EquipmentSlot.MAINHAND,
+                        mergedMap, stack.isOf(ModItems.MIRROR_OF_EVALUATION), true
                 );
             }
         });


### PR DESCRIPTION
it was unconditionally sending an empty hash map for the macros

fixes #163