### PR TITLE
fix showcase ploy throwing an exception when called with no arguments

### DIFF
--- a/src/main/java/dev/enjarai/trickster/spell/trick/basic/RevealTrick.java
+++ b/src/main/java/dev/enjarai/trickster/spell/trick/basic/RevealTrick.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 public class RevealTrick extends Trick<RevealTrick> {
     public RevealTrick() {
-        super(Pattern.of(3, 4, 5, 8, 7, 6, 3), Signature.of(variadic(Fragment.class), RevealTrick::reveal));
+        super(Pattern.of(3, 4, 5, 8, 7, 6, 3), Signature.of(variadic(Fragment.class).require(), RevealTrick::reveal));
     }
 
     public Fragment reveal(SpellContext ctx, List<Fragment> fragments) throws BlunderException {


### PR DESCRIPTION
fixes #156

was missing a .require(), so the ploy would happily try to work with the first element of an empty fragment list and throw NoSuchElementException