### PR TITLE
Update trick previews to use most recent serialization format

### DIFF
--- a/src/client/java/dev/enjarai/trickster/coleus/TricksterTemplateExpanders.java
+++ b/src/client/java/dev/enjarai/trickster/coleus/TricksterTemplateExpanders.java
@@ -142,7 +142,7 @@ public class TricksterTemplateExpanders {
         var urlEncodedSpellString = URLEncoder.encode(spellString, StandardCharsets.UTF_8);
 
         return div().withClass("spell-preview").with(
-                iframe().withSrc("https://trickster-studio.maplesyrum.me/viewer/?fixed=false&spell=" + urlEncodedSpellString)
+                iframe().withSrc("https://trickster-studio.maplesyrum.me/viewer/?transparent=true&fixed=false&spell=" + urlEncodedSpellString)
                         .attr("allowtransparency", "true")
                         .withClass("spell-preview-iframe"),
                 script(new UnescapedText(

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/landing_page.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/landing_page.md
@@ -4,4 +4,4 @@
 }
 ```
 
-<|spell-preview@trickster:templates|spell=YwyT9+Z3YJjPxgRiMLg4cDGDGIwMDgyMIAZHCAMDg9azL5ogToCHQydYdIMPA0RakYGJEcwI4HHoxKcQaGAnE4TBwAEWYWBUQLICjxkLGhwaoVqZIArBDAYAAInoArsAAAA=|>
+<|spell-preview@trickster:templates|spell=YxEpKcpMzi4uSS2yKi5IzcmJL0gsKhFECBYklgCpPAeG+WxMjPwMDAzMQMzAyIiphMHFgQshT6S5AR4OnYyMQvjM3eADksEtz8jg0IlPPoAHLM9EwBAGDryeY1TAq58jBOxIJrwEOUHDSUnQKDIwMRIbNNjdijW4SQ0JRmZaeH5Bg0MjfocS5RsMzwMA4HzrBxMDAAA=|>

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/tutorials/2_mana_basics.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/tutorials/2_mana_basics.md
@@ -71,6 +71,6 @@ Create a few of these before continuing!
 
 ;;;;;
 
-<|spell-preview-unloadable@trickster:templates|spell=YwqT9+b/wDGjlQEAks2CzAoAAAA=|>
+<|spell-preview-unloadable@trickster:templates|spell=YxEpKcpMzi4uSS2yKi5IzcmJL0gsKhFECBYklgCpvA8cM1oZAKSkMy4tAAAA|>
 
 {gray}(Drag to pan and scroll to zoom){}

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/tutorials/3_first_spell.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/tutorials/3_first_spell.md
@@ -34,7 +34,7 @@ With that out of the way, try to recreate the following spell in your scroll:
 
 ;;;;;
 
-<|spell-preview-unloadable@trickster:templates|spell=YwyT9+YP6GBjZQQxGFwOMIAZHCEMDAwA8vUGkRwAAAA=|>
+<|spell-preview-unloadable@trickster:templates|spell=YxEpKcpMzi4uSS2yKi5IzcmJL0gsKhFECBYklgCpvIAONlZGRjYGBgZmIGZgZMRUwuBygAGfPEcISIaBCUIAAFAX+BF5AAAA|>
 
 {gray}(Drag to pan and scroll to zoom){}
 
@@ -42,7 +42,7 @@ With that out of the way, try to recreate the following spell in your scroll:
 
 Once that's done, hold the scroll in your offhand, and draw the following spell in your mirror:
 
-<|spell-preview-unloadable@trickster:templates|spell=YwyT9+bf6MPEyghiMLo0tTIAADybrxgTAAAA|>
+<|spell-preview-unloadable@trickster:templates|spell=YxEpKcpMzi4uSS2yKi5IzcmJL0gsKhFECBYklgCpvI0+TKyMjMwMDAwgzMDIiKmE0aWpFSjFxAAAWHSAFlQAAAA=|>
 
 ;;;;;
 

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/tutorials/4_easier_casting.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/tutorials/4_easier_casting.md
@@ -39,7 +39,7 @@ You can use a spell like the following in a mirror to read and inscribe a spell.
 
 First draw the small pattern while holding your spell, 
 then swap to the item you want to inscribe, and draw the other pattern.
-<|spell-preview-unloadable@trickster:templates|spell=YwyT9+bf6MPEwAhiMLo0tTIAAH43+GkTAAAA|>
+<|spell-preview-unloadable@trickster:templates|spell=YxEpKcpMzi4uSS2yKi5IzcmJL0gsKhFECBYklgCpvI0+TAyMjMwMDAwgDGRiKmF0aWoFSjExAAD/qivoVAAAAA==|>
 
 ;;;;;
 
@@ -56,7 +56,7 @@ Combining all this, try inscribing the following spell onto a Wand:
 
 ;;;;;
 
-<|spell-preview@trickster:templates|spell=YwyT9+ZnYDjAwwhiMDI4dDKBRVwOMIBFOEIYGBhADCEUEQDelYOZNwAAAA==|>
+<|spell-preview@trickster:templates|spell=YxEpKcpMzi4uSS2yKi5IzcmJL0gsKhFECBYklgCpPAaGAzyMjPwMDAzMQMzAyIiphJHBoROfvJDLAQZ88hwhIBkGJjiBUyUDqSYxMQAA0uzvpegAAAA=|>
 
 Once you have it inscribed, try it out to see what it does.
 After that, try looking up the tricks to see *how*!

--- a/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/tutorials/5_spell_structure.md
+++ b/src/main/resources/assets/trickster/lavender/entries/tome_of_tomfoolery/tutorials/5_spell_structure.md
@@ -32,7 +32,7 @@ check out [the entry explaining them in more detail](^trickster:concepts/signatu
 
 ;;;;;
 
-<|spell-preview-unloadable@trickster:templates|spell=YwyT9+ZnAAIW9/lWJxhgAMSx/4DEcUCWceCAcgC7HdBfPgAAAA==|>
+<|spell-preview-unloadable@trickster:templates|spell=YxEpKcpMzi4uSS2yKi5IzcmJL0gsKhFECBYklgCpPAYgYGFkBpIgzMDIKIBQkleam5RaxIAATAx4Vdp/IFalA9FmOnAgqQQASzjP+tUAAAA=|>
 
 Take a look at the spell above.
 Its subcircles are labelled with the order they're cast, from 0 to 3.


### PR DESCRIPTION
trickster studio will not be supporting older trick serialization formats, so all spell previews must be updated for them to render properly in the web book.